### PR TITLE
Style/17/styled setup

### DIFF
--- a/client/.babelrc
+++ b/client/.babelrc
@@ -1,0 +1,4 @@
+{
+	"presets": ["next/babel"],
+	"plugins": [["styled-components", { "ssr": true }]]
+  }

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -2947,6 +2947,15 @@
       "integrity": "sha512-oZ0Ib5I4Z2pUEcoo95cT1cr6slco9WY7yiPpG+RGNkj8YcYgJnM7pXmYmorNOReh8MIGcKSqXyeGjxnr8YiZbA==",
       "dev": true
     },
+    "@types/axios": {
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/@types/axios/-/axios-0.14.0.tgz",
+      "integrity": "sha1-7CMA++fX3d1+udOr+HmZlkyvzkY=",
+      "dev": true,
+      "requires": {
+        "axios": "*"
+      }
+    },
     "@types/babel__core": {
       "version": "7.1.9",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.9.tgz",
@@ -3953,6 +3962,37 @@
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.10.0.tgz",
       "integrity": "sha512-3YDiu347mtVtjpyV3u5kVqQLP242c06zwDOgpeRnybmXlYYsLbtTrUBUm8i8srONt+FWobl5aibnU1030PeeuA=="
+    },
+    "axios": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.19.2.tgz",
+      "integrity": "sha512-fjgm5MvRHLhx+osE2xoekY70AhARk3a6hkN+3Io1jc00jtquGvxYlKlsFUhmUET0V5te6CcZI7lcv2Ym61mjHA==",
+      "requires": {
+        "follow-redirects": "1.5.10"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "follow-redirects": {
+          "version": "1.5.10",
+          "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
+          "integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
+          "requires": {
+            "debug": "=3.1.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+        }
+      }
     },
     "axobject-query": {
       "version": "2.2.0",
@@ -15211,6 +15251,11 @@
           "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ=="
         }
       }
+    },
+    "styled-reset": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/styled-reset/-/styled-reset-4.2.2.tgz",
+      "integrity": "sha512-HOYxeqR5xUqq7mHCcbtHYpH8HuNuBcyVJfltxuJb9RatffjY3ifTqukoSUjW3iPWZp7hGEV8Kk9CFGi54M2nsA=="
     },
     "stylehacks": {
       "version": "4.0.3",

--- a/client/package.json
+++ b/client/package.json
@@ -3,10 +3,12 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
+    "axios": "^0.19.2",
     "next": "^9.5.2",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
-    "react-scripts": "3.4.1"
+    "react-scripts": "3.4.1",
+    "styled-reset": "^4.2.2"
   },
   "scripts": {
     "dev": "next -p 9000",
@@ -34,6 +36,7 @@
     "@testing-library/jest-dom": "^4.2.4",
     "@testing-library/react": "^9.3.2",
     "@testing-library/user-event": "^7.1.2",
+    "@types/axios": "^0.14.0",
     "@types/jest": "^24.0.0",
     "@types/node": "^12.12.54",
     "@types/react": "^16.9.46",

--- a/client/src/pages/_app.tsx
+++ b/client/src/pages/_app.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import { AppProps } from 'next/app';
+import GlobalStyle from '../styles/GlobalStyle';
+
+const App = ({ Component, pageProps }: AppProps) => {
+  return (
+    <>
+      <GlobalStyle />
+      <Component {...pageProps} />
+    </>
+  );
+};
+
+export default App;

--- a/client/src/pages/_document.tsx
+++ b/client/src/pages/_document.tsx
@@ -1,0 +1,30 @@
+import Document, { DocumentContext } from 'next/document';
+import { ServerStyleSheet } from 'styled-components';
+
+export default class MyDocument extends Document {
+  static async getInitialProps(ctx: DocumentContext) {
+    const sheet = new ServerStyleSheet();
+    const originalRenderPage = ctx.renderPage;
+
+    try {
+      ctx.renderPage = () =>
+        originalRenderPage({
+          enhanceApp: (App) => (props) =>
+            sheet.collectStyles(<App {...props} />),
+        });
+
+      const initialProps = await Document.getInitialProps(ctx);
+      return {
+        ...initialProps,
+        styles: (
+          <>
+            {initialProps.styles}
+            {sheet.getStyleElement()}
+          </>
+        ),
+      };
+    } finally {
+      sheet.seal();
+    }
+  }
+}

--- a/client/src/styles/GlobalStyle.tsx
+++ b/client/src/styles/GlobalStyle.tsx
@@ -1,0 +1,23 @@
+import reset from 'styled-reset';
+import { createGlobalStyle } from 'styled-components';
+
+const GlobalStyle = createGlobalStyle`
+  ${reset}
+  * {
+    box-sizing: border-box;
+  }
+  body{
+    font-family: -apple-system,system-ui,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",Arial,sans-serif;
+  }
+  a {
+    color: inherit;
+    text-decoration: none;
+  }
+  input, button {
+    background-color: transparent;
+    border: none;
+    outline: none;
+  }
+`;
+
+export default GlobalStyle;


### PR DESCRIPTION
## styled-component for NEXT.js(SSR)

### Problems
ssr(server side renderig)은 기본적으로 서버에서 완성된 HTML마크업을 자바스크립트 로딩 전에 쏴주는 형태인데, styled-component는 `css-in-js`형식의 스타일러로, 마크업이 렌더된 뒤에 자바스크립트에서 실행된 스타일이 추가되는 형태입니다. 그래서 새로고침 되었을 때 그냥 마크업이 뜨거나, 혹은 렌더가 늦어져서 깜빡이는 현상이 발생하는 문제점이 있습니다.

### Solution
NEXT는 각각의 페이지가 로딩될 때 기본적으로 참조하는 `_document.tsx` 파일이 있는데, 공식적으로 이 [파일을 덮어쓰는 방법을 제안](https://github.com/vercel/next.js/tree/master/examples/with-typescript-styled-components)하고 있습니다. 뿐만 아니라 `babel-plugin-styled-components`라는 플러그인을 바벨 설정에 `{ssr : true}` 라는 옵션과 함께 추가하면 해당 문제를 해결할 수 있습니다.

### 참고자료
- [nextjs official document for styled-compoent](https://github.com/vercel/next.js/tree/master/examples/with-typescript-styled-components)
- [nextjs에서 styled-component가 제대로 작동하지 않는 버그 수정](https://velog.io/@janghyoin/Jobshopper-project-NextJS%EC%97%90%EC%84%9C-styled-components-%EC%82%AC%EC%9A%A9-hwjzs423yw)
- [ts, next, styled-component 개발환경 설정](https://velog.io/@jjunn0/Next-x-Ts-x-styled-component-x-jest)
Resolve #17 
