### PR TITLE
Feat/53/nextjs store setup

### DIFF
--- a/client/src/context/CategoryContext.tsx
+++ b/client/src/context/CategoryContext.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { contextCreator } from '../utils/createContext';
 import { Category } from '../../../shared';
 
-export type CategoryState = Category[];
+export type CategoryState = Category[] | null;
 
 export type CategoryAction = { type: 'FETCH_CATEGORY'; categories: Category[] };
 
@@ -12,13 +12,13 @@ const CategoryReducer = (
 ): CategoryState => {
   switch (action.type) {
     case 'FETCH_CATEGORY':
-      return [...state, ...action.categories];
+      return [...action.categories];
     default:
       throw new Error('Unhandled action');
   }
 };
 
-const initialCategory: CategoryState = [];
+const initialCategory: CategoryState = null;
 
 export const {
   ContextProvider: CategoryProvider,

--- a/client/src/context/index.tsx
+++ b/client/src/context/index.tsx
@@ -1,0 +1,10 @@
+import { CombineProviderApp } from '../utils/createContext';
+import { CounterProvider } from '../context/CounterContext';
+import { CategoryProvider } from '../context/CategoryContext';
+import { ProductProvider } from '../context/ProductContext';
+
+export const CombinedProviders = CombineProviderApp(
+  CounterProvider,
+  CategoryProvider,
+  ProductProvider
+);

--- a/client/src/hooks/useCategory.tsx
+++ b/client/src/hooks/useCategory.tsx
@@ -4,19 +4,20 @@ import { CategoryContexts } from '../context/CategoryContext';
 import { Category } from '../../../shared';
 import { fetchCategory } from '../api';
 
-export const useCategory = (init = false) => {
+export const useCategory = (categories?: Category[]) => {
   const [category, dispatch] = useCreator(CategoryContexts);
 
   useEffect(() => {
-    init && getCategory();
-  }, [init]);
+    if (categories) {
+      setCategory(categories);
+    }
+  }, [categories]);
 
-  const getCategory = async () => {
-    const categories = await fetchCategory();
+  const setCategory = async (categories: Category[]) => {
     dispatch({ type: 'FETCH_CATEGORY', categories });
   };
 
-  return { category, getCategory };
+  return { category };
 
   // or make custom action creator
   // const doSomething = () => dispatch({type : 'DO_SOMETHING'})

--- a/client/src/pages/_document.tsx
+++ b/client/src/pages/_document.tsx
@@ -3,9 +3,9 @@ import { ServerStyleSheet } from 'styled-components';
 
 export default class MyDocument extends Document {
   static async getInitialProps(ctx: DocumentContext) {
+    /* styled-component 적용이 안 되는 문제를 해결하기 위한 코드*/
     const sheet = new ServerStyleSheet();
     const originalRenderPage = ctx.renderPage;
-
     try {
       ctx.renderPage = () =>
         originalRenderPage({

--- a/client/src/pages/admin_andy.tsx
+++ b/client/src/pages/admin_andy.tsx
@@ -5,57 +5,7 @@ import { useProduct } from '../hooks/useProduct';
 import { CartItem } from '../components/CartItem';
 
 const AdminPage = () => {
-  const { category } = useCategory();
-  const { products, setProductByCategory2_id } = useProduct();
-  const [index, setIndex] = useState(0);
-  const [cate2Id, setCate2Id] = useState(
-    category[index].subCategory![0].id || -1
-  );
-
-  useEffect(() => {
-    if (cate2Id !== -1) {
-      setProductByCategory2_id(cate2Id);
-    }
-  }, [cate2Id]);
-
-  useEffect(() => {
-    const currentFirstSubCategoryId = category[index].subCategory![0].id;
-    setCate2Id(currentFirstSubCategoryId);
-  }, [index]);
-
-  return (
-    <>
-      <FileUploader />
-      <select name="cate1" onChange={(e) => setIndex(Number(e.target.value))}>
-        {category.map((cate, idx) => (
-          <option key={cate.id} value={idx}>
-            {cate.name}
-          </option>
-        ))}
-      </select>
-      <select name="cate2" onChange={(e) => setCate2Id(+e.target.value)}>
-        {category[index].subCategory?.map((cate) => (
-          <option key={cate.id} value={cate.id}>
-            {cate.name}
-          </option>
-        ))}
-      </select>
-      <div>
-        {products.map((product) => (
-          <CartItem
-            key={product.id}
-            id={product.id}
-            checked={false}
-            name={product.name}
-            img={`http://${product.image}`}
-            discount={product.discount}
-            price={product.price}
-            base_price={product.basePrice}
-          ></CartItem>
-        ))}
-      </div>
-    </>
-  );
+  return <></>;
 };
 
 export default AdminPage;

--- a/client/src/pages/admin_bg.tsx
+++ b/client/src/pages/admin_bg.tsx
@@ -3,14 +3,13 @@ import { useCategory } from '../hooks/useCategory';
 import React, { useState, useEffect } from 'react';
 import { useProduct } from '../hooks/useProduct';
 import { CartItem } from '../components/CartItem';
+import Link from 'next/link';
 
 const AdminPage = () => {
   const { category } = useCategory();
   const { products, setProductByCategory2_id } = useProduct();
   const [index, setIndex] = useState(0);
-  const [cate2Id, setCate2Id] = useState(
-    category[index].subCategory![0].id || -1
-  );
+  const [cate2Id, setCate2Id] = useState(-1);
 
   useEffect(() => {
     if (cate2Id !== -1) {
@@ -19,26 +18,33 @@ const AdminPage = () => {
   }, [cate2Id]);
 
   useEffect(() => {
-    const currentFirstSubCategoryId = category[index].subCategory![0].id;
-    setCate2Id(currentFirstSubCategoryId);
-  }, [index]);
+    if (category) {
+      const currentFirstSubCategoryId = category[index].subCategory![0].id;
+      setCate2Id(currentFirstSubCategoryId);
+    }
+  }, [category, index]);
 
   return (
     <>
+      <Link href="/">
+        <a>go to card</a>
+      </Link>
       <FileUploader />
       <select name="cate1" onChange={(e) => setIndex(Number(e.target.value))}>
-        {category.map((cate, idx) => (
-          <option key={cate.id} value={idx}>
-            {cate.name}
-          </option>
-        ))}
+        {category &&
+          category.map((cate, idx) => (
+            <option key={cate.id} value={idx}>
+              {cate.name}
+            </option>
+          ))}
       </select>
       <select name="cate2" onChange={(e) => setCate2Id(+e.target.value)}>
-        {category[index].subCategory?.map((cate) => (
-          <option key={cate.id} value={cate.id}>
-            {cate.name}
-          </option>
-        ))}
+        {category &&
+          category[index].subCategory?.map((cate) => (
+            <option key={cate.id} value={cate.id}>
+              {cate.name}
+            </option>
+          ))}
       </select>
       <div>
         {products.map((product) => (

--- a/client/src/pages/admin_cn.tsx
+++ b/client/src/pages/admin_cn.tsx
@@ -5,63 +5,7 @@ import { useProduct } from '../hooks/useProduct';
 import { CartItem } from '../components/CartItem';
 
 const AdminPage = () => {
-  const { category } = useCategory();
-  const { products, setProductByCategory2_id } = useProduct();
-  const [index, setIndex] = useState(0);
-  const [cate2Id, setCate2Id] = useState(0);
-
-  const setCategory = (index: number) => {
-    setIndex(index);
-    setCate2Id(category[index].subCategory![0].id);
-    setProduct(cate2Id);
-  };
-
-  const setProduct = async (category2_id: string | number) => {
-    setCate2Id(+category2_id);
-    console.log('curr category2_id=', cate2Id);
-    if (cate2Id === 0) {
-      console.log('초기데이터 필요없어', cate2Id);
-      return;
-    }
-    await setProductByCategory2_id(cate2Id);
-  };
-
-  return (
-    <>
-      <FileUploader />
-      <select
-        name="cate1"
-        onChange={(e) => setCategory(Number(e.target.value))}
-      >
-        {category.map((cate, idx) => (
-          <option key={cate.id} value={idx}>
-            {cate.name}
-          </option>
-        ))}
-      </select>
-      <select name="cate2" onChange={(e) => setProduct(e.target.value)}>
-        {category[index].subCategory?.map((cate) => (
-          <option key={cate.id} value={cate.id}>
-            {cate.name}
-          </option>
-        ))}
-      </select>
-      <div>
-        {products.map((product) => (
-          <CartItem
-            key={product.id}
-            id={product.id}
-            checked={false}
-            name={product.name}
-            img={`http://${product.image}`}
-            discount={product.discount}
-            price={product.price}
-            base_price={product.basePrice}
-          ></CartItem>
-        ))}
-      </div>
-    </>
-  );
+  return <></>;
 };
 
 export default AdminPage;

--- a/client/src/pages/index.tsx
+++ b/client/src/pages/index.tsx
@@ -1,9 +1,7 @@
 import React from 'react';
 import Link from 'next/link';
-import { useCategory } from '../hooks/useCategory';
 
 const IndexPage = () => {
-  useCategory(true);
   return (
     <>
       <h1> helle bmart - 9</h1>


### PR DESCRIPTION
## Global store setup
NEXT(SSR)환경에서 글로벌 store(context api로 만들어진) 설정. 

## lief cycle
기존에 데이터를 fetch해 오는 방법은 componentDidMount lifeCycle을 이용해서 비어있는(데이터를 이용하지 않는) 마크업을 렌더한 뒤에, [useEffect](https://ko.reactjs.org/docs/hooks-effect.html) 를 이용하여 데이터를 가져오고, 해당 데이터를 뿌려서 이용하는 방식을 이용했습니다. 하지만 SSR에서는 데이터를 먼저 가져오고, 해당 데이터를 이용한 `완성된` 마크업을 렌더해줍니다.

```
CSR : render -> componenetDidMount(data fetch) -> render with full data
SSR : data fetch -> render with full data
```

## _app.tsx
nextjs에서는 기존 리액트 환경에서 `App` 컴포넌트를 만들고, 해당 컴포넌트를 `RenderDOM.render`을 이용해서 렌더해주는 것을 대신 해줌. 즉, App이라는 엔트리 포인트를 따로 설정하지 않아도 자동으로 해줌. 하지만 Provider` 등을 설정하는 것을 대비하여, _app.[js, jsx, ts, tsx] 파일을 `pages`폴더 내에 만들어두면, 해당 파일을 엔트리포인트로 이용함. 

## getInitialProps
SSR(Server Side Rendering) 방식을 이용하여 서버에서 가져온 데이터를 initialize 하기 위해서는 `_app.tsx`파일에서 해당 과정이 필요함. 하지만 _app 파일 내부에 `getInitialProps` 함수를 호출하면, 모든 페이지에 접근할 때 마다 _app의 커스텀 App 컴포넌트를 실행하는 문제점이 있음. [넥스트 공식문서 하단 사진의 커멘트](https://nextjs.org/docs/basic-features/typescript#custom-app) 되어있는 부분에 설명이 되고 있음.

![image](https://user-images.githubusercontent.com/30615804/90669115-155df780-e28c-11ea-906a-23b40edd1982.png)

## IS_INITIALIZED
일단 당장 문제를 해결하기 위해 글로벌 변수 `IS_INITIALIZED`를 만들어서, 최초에 한번만 필요한 데이터를 가져오고 나머지 스토어를 설정하는 것으로 함

Resolve #53 
