### PR TITLE
[#57] feat : 메인 페이지 컴포넌트 배치

### DIFF
--- a/client/src/components/CardSetWithCategory/CardSetWithCategory.test.tsx
+++ b/client/src/components/CardSetWithCategory/CardSetWithCategory.test.tsx
@@ -1,0 +1,19 @@
+import '@testing-library/jest-dom/extend-expect';
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react';
+
+import {CardSetWithCategory} from './';
+
+describe('CardSetWithCategory comopoent', () => {
+  it('matches snapshot', () => {
+    const { container } = render(<CardSetWithCategory />);
+    expect(container).toMatchSnapshot();
+  });
+
+  it('shows the elemnts correctly', () => {
+    const utils = render(<CardSetWithCategory />);
+    // utils.getByText('+');
+
+  });
+});
+

--- a/client/src/components/CardSetWithCategory/CardSetWithCategory.tsx
+++ b/client/src/components/CardSetWithCategory/CardSetWithCategory.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import * as S from './CardSetWithCategoryStyle';
+
+type Props = {}
+
+const CardSetWithCategory: React.FC<Props> = ({} : Props) => {
+
+	return <S.Container>CardSetWithCategory</S.Container>;
+};
+
+export default CardSetWithCategory;
+

--- a/client/src/components/CardSetWithCategory/CardSetWithCategoryStyle.ts
+++ b/client/src/components/CardSetWithCategory/CardSetWithCategoryStyle.ts
@@ -1,0 +1,9 @@
+import styled from 'styled-components';
+
+export const Container = styled.div`
+  width:100vw;
+  height: 20vh;
+  text-align:center;
+  background-color:grey;
+`
+

--- a/client/src/components/CardSetWithCategory/index.ts
+++ b/client/src/components/CardSetWithCategory/index.ts
@@ -1,0 +1,1 @@
+export {default as CardSetWithCategory} from './CardSetWithCategory'

--- a/client/src/components/GridCardSet/GridCardSet.test.tsx
+++ b/client/src/components/GridCardSet/GridCardSet.test.tsx
@@ -1,0 +1,19 @@
+import '@testing-library/jest-dom/extend-expect';
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react';
+
+import {GridCardSet} from './';
+
+describe('GridCardSet comopoent', () => {
+  it('matches snapshot', () => {
+    const { container } = render(<GridCardSet />);
+    expect(container).toMatchSnapshot();
+  });
+
+  it('shows the elemnts correctly', () => {
+    const utils = render(<GridCardSet />);
+    // utils.getByText('+');
+
+  });
+});
+

--- a/client/src/components/GridCardSet/GridCardSet.tsx
+++ b/client/src/components/GridCardSet/GridCardSet.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import * as S from './GridCardSetStyle';
+
+type Props = {}
+
+const GridCardSet: React.FC<Props> = ({} : Props) => {
+
+	return <S.Container>GridCardSet</S.Container>;
+};
+
+export default GridCardSet;
+

--- a/client/src/components/GridCardSet/GridCardSetStyle.ts
+++ b/client/src/components/GridCardSet/GridCardSetStyle.ts
@@ -1,0 +1,8 @@
+import styled from 'styled-components';
+
+export const Container = styled.div`
+  width:100vw;
+  height: 20vh;
+  text-align:center;
+  background-color:grey;
+`

--- a/client/src/components/GridCardSet/index.ts
+++ b/client/src/components/GridCardSet/index.ts
@@ -1,0 +1,1 @@
+export {default as GridCardSet} from './GridCardSet'

--- a/client/src/components/MainCategorySet/MainCategorySet.test.tsx
+++ b/client/src/components/MainCategorySet/MainCategorySet.test.tsx
@@ -1,0 +1,19 @@
+import '@testing-library/jest-dom/extend-expect';
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react';
+
+import {MainCategorySet} from './';
+
+describe('MainCategorySet comopoent', () => {
+  it('matches snapshot', () => {
+    const { container } = render(<MainCategorySet />);
+    expect(container).toMatchSnapshot();
+  });
+
+  it('shows the elemnts correctly', () => {
+    const utils = render(<MainCategorySet />);
+    // utils.getByText('+');
+
+  });
+});
+

--- a/client/src/components/MainCategorySet/MainCategorySet.tsx
+++ b/client/src/components/MainCategorySet/MainCategorySet.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import * as S from './MainCategorySetStyle';
+
+type Props = {}
+
+const MainCategorySet: React.FC<Props> = ({} : Props) => {
+
+	return <S.Container>MainCategorySet</S.Container>;
+};
+
+export default MainCategorySet;
+

--- a/client/src/components/MainCategorySet/MainCategorySetStyle.ts
+++ b/client/src/components/MainCategorySet/MainCategorySetStyle.ts
@@ -1,0 +1,9 @@
+import styled from 'styled-components';
+
+export const Container = styled.div`
+  width:100vw;
+  height: 20vh;
+  text-align:center;
+  background-color:grey;
+`
+

--- a/client/src/components/MainCategorySet/index.ts
+++ b/client/src/components/MainCategorySet/index.ts
@@ -1,0 +1,1 @@
+export {default as MainCategorySet} from './MainCategorySet'

--- a/client/src/components/MainFooter/MainFooter.test.tsx
+++ b/client/src/components/MainFooter/MainFooter.test.tsx
@@ -1,0 +1,19 @@
+import '@testing-library/jest-dom/extend-expect';
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react';
+
+import {MainFooter} from './';
+
+describe('MainFooter comopoent', () => {
+  it('matches snapshot', () => {
+    const { container } = render(<MainFooter />);
+    expect(container).toMatchSnapshot();
+  });
+
+  it('shows the elemnts correctly', () => {
+    const utils = render(<MainFooter />);
+    // utils.getByText('+');
+
+  });
+});
+

--- a/client/src/components/MainFooter/MainFooter.tsx
+++ b/client/src/components/MainFooter/MainFooter.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import * as S from './MainFooterStyle';
+
+type Props = {}
+
+const MainFooter: React.FC<Props> = ({} : Props) => {
+
+	return <S.Container>MainFooter</S.Container>;
+};
+
+export default MainFooter;
+

--- a/client/src/components/MainFooter/MainFooterStyle.ts
+++ b/client/src/components/MainFooter/MainFooterStyle.ts
@@ -1,0 +1,9 @@
+import styled from 'styled-components';
+
+export const Container = styled.div`
+  width:100vw;
+  height: 20vh;
+  text-align:center;
+  background-color:grey;
+`
+

--- a/client/src/components/MainFooter/index.ts
+++ b/client/src/components/MainFooter/index.ts
@@ -1,0 +1,1 @@
+export {default as MainFooter} from './MainFooter'

--- a/client/src/components/PullToRefresh/PullToRefresh.test.tsx
+++ b/client/src/components/PullToRefresh/PullToRefresh.test.tsx
@@ -1,0 +1,19 @@
+import '@testing-library/jest-dom/extend-expect';
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react';
+
+import {PullToRefresh} from './';
+
+describe('PullToRefresh comopoent', () => {
+  it('matches snapshot', () => {
+    const { container } = render(<PullToRefresh />);
+    expect(container).toMatchSnapshot();
+  });
+
+  it('shows the elemnts correctly', () => {
+    const utils = render(<PullToRefresh />);
+    // utils.getByText('+');
+
+  });
+});
+

--- a/client/src/components/PullToRefresh/PullToRefresh.tsx
+++ b/client/src/components/PullToRefresh/PullToRefresh.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import * as S from './PullToRefreshStyle';
+
+type Props = {}
+
+const PullToRefresh: React.FC<Props> = ({} : Props) => {
+
+	return <S.Container>PullToRefresh</S.Container>;
+};
+
+export default PullToRefresh;
+

--- a/client/src/components/PullToRefresh/PullToRefreshStyle.ts
+++ b/client/src/components/PullToRefresh/PullToRefreshStyle.ts
@@ -1,0 +1,8 @@
+import styled from 'styled-components';
+
+export const Container = styled.div`
+  width:100vw;
+  height: 20vh;
+  text-align:center;
+  background-color:grey;
+`

--- a/client/src/components/PullToRefresh/index.ts
+++ b/client/src/components/PullToRefresh/index.ts
@@ -1,0 +1,1 @@
+export {default as PullToRefresh} from './PullToRefresh'

--- a/client/src/components/ShowcaseCardSet/ShowcaseCardSet.test.tsx
+++ b/client/src/components/ShowcaseCardSet/ShowcaseCardSet.test.tsx
@@ -1,0 +1,19 @@
+import '@testing-library/jest-dom/extend-expect';
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react';
+
+import {ShowcaseCardSet} from './';
+
+describe('ShowcaseCardSet comopoent', () => {
+  it('matches snapshot', () => {
+    const { container } = render(<ShowcaseCardSet />);
+    expect(container).toMatchSnapshot();
+  });
+
+  it('shows the elemnts correctly', () => {
+    const utils = render(<ShowcaseCardSet />);
+    // utils.getByText('+');
+
+  });
+});
+

--- a/client/src/components/ShowcaseCardSet/ShowcaseCardSet.tsx
+++ b/client/src/components/ShowcaseCardSet/ShowcaseCardSet.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import * as S from './ShowcaseCardSetStyle';
+
+type Props = {}
+
+const ShowcaseCardSet: React.FC<Props> = ({} : Props) => {
+
+	return <S.Container>ShowcaseCardSet</S.Container>;
+};
+
+export default ShowcaseCardSet;
+

--- a/client/src/components/ShowcaseCardSet/ShowcaseCardSetStyle.ts
+++ b/client/src/components/ShowcaseCardSet/ShowcaseCardSetStyle.ts
@@ -1,0 +1,8 @@
+import styled from 'styled-components';
+
+export const Container = styled.div`
+  width:100vw;
+  height: 20vh;
+  text-align:center;
+  background-color:grey;
+`

--- a/client/src/components/ShowcaseCardSet/index.ts
+++ b/client/src/components/ShowcaseCardSet/index.ts
@@ -1,0 +1,1 @@
+export {default as ShowcaseCardSet} from './ShowcaseCardSet'

--- a/client/src/context/ProductContext.tsx
+++ b/client/src/context/ProductContext.tsx
@@ -14,7 +14,7 @@ const ProductReducer = (
 ): ProductState => {
   switch (action.type) {
     case 'SET_PRODUCT_LIST':
-      return (state = action.productList); // new state
+      return [...action.productList]; // new state
     default:
       throw new Error('Unhandled action');
   }

--- a/client/src/pages/index.tsx
+++ b/client/src/pages/index.tsx
@@ -9,6 +9,10 @@ const IndexPage = () => {
         <a>go to counter</a>
       </Link>
       <br />
+      <Link href="/main">
+        <a>go to main</a>
+      </Link>
+      <br />
       <Link href="/card">
         <a>go to card</a>
       </Link>

--- a/client/src/pages/main.tsx
+++ b/client/src/pages/main.tsx
@@ -1,0 +1,53 @@
+import { HorizontalBar } from '../components/HorizontalBar';
+import { Carousel } from '../components/Carousel';
+import { PromotionImgDataProps } from './../components/Carousel/Carousel';
+import { HorizontalCardSet } from '../components/HorizontalCardSet';
+import { MainCategorySet } from '../components/MainCategorySet';
+import { PullToRefresh } from '../components/PullToRefresh';
+import { GridCardSet } from '../components/GridCardSet';
+import { ShowcaseCardSet } from '../components/ShowcaseCardSet';
+import { CardSetWithCategory } from '../components/CardSetWithCategory';
+import { MainFooter } from '../components/MainFooter';
+
+const promotionImgData : PromotionImgDataProps[] = [
+	{id: 1, imgSrc: "https://images.unsplash.com/photo-1554774853-b3d587d95440?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=3526&q=80"},
+	{id: 2, imgSrc: "https://images.unsplash.com/photo-1585840888857-a83673aad0f2?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=3450&q=80"},
+	{id: 3, imgSrc: "https://images.unsplash.com/photo-1593642532744-d377ab507dc8?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=2100&q=80"},
+	{id: 4, imgSrc: "https://images.unsplash.com/photo-1597346906996-ab57d9b27dda?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=2100&q=80"},
+	{id: 5, imgSrc: "https://images.unsplash.com/photo-1593642632559-0c6d3fc62b89?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=2100&q=80"},
+	{id: 6, imgSrc: "https://images.unsplash.com/photo-1593642533144-3d62aa4783ec?ixlib=rb-1.2.1&auto=format&fit=crop&w=2100&q=80"},
+	{id: 7, imgSrc: "https://images.unsplash.com/photo-1593642634524-b40b5baae6bb?ixlib=rb-1.2.1&auto=format&fit=crop&w=2389&q=80"},
+	{id: 8, imgSrc: "https://images.unsplash.com/photo-1597541711530-c9cab34d8937?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=2100&q=80"},
+	{id: 9, imgSrc: "https://images.unsplash.com/photo-1597557316151-a79617e6d3d3?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=2102&q=80"},
+	{id: 10, imgSrc: "https://images.unsplash.com/photo-1597513901462-48cb0a4055f8?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=2100&q=80"}
+]
+
+const data : CardProps[] = [
+	{id: 1, imgSrc: "https://www.pngitem.com/pimgs/m/664-6644509_icon-react-js-logo-hd-png-download.png", productData: { productName: "초보탈출 리액트", productDiscountRate:99, productBasePrice: 1000, productPrice:80}},
+	{id: 2, imgSrc: "https://images-na.ssl-images-amazon.com/images/I/61aOa%2B4v4IL._AC_SL1240_.jpg", productData: { productName: "맥 딜리버리", productDiscountRate:99, productBasePrice: 1000, productPrice:110}},
+	{id: 3, imgSrc: "https://gd.image-gmkt.com/li/143/151/648151143.g_520-w_g.jpg", productData: { productName: "해피퍼킹 키보드", productDiscountRate:50, productBasePrice: 2000, productPrice:130}},
+	{id: 4, imgSrc: "https://gd.image-gmkt.com/li/143/151/648151143.g_520-w_g.jpg", productData: { productName: "해피퍼킹 키보드", productDiscountRate:50, productBasePrice: 2000, productPrice:1000}},
+	{id: 5, imgSrc: "https://gd.image-gmkt.com/li/143/151/648151143.g_520-w_g.jpg", productData: { productName: "해피퍼킹 키보드", productDiscountRate:0, productBasePrice: 9000, productPrice:9000}},
+	{id: 6, imgSrc: "https://gd.image-gmkt.com/li/143/151/648151143.g_520-w_g.jpg", productData: { productName: "해피퍼킹 키보드", productDiscountRate:10, productBasePrice: 1000, productPrice:900}},
+	{id: 7, imgSrc: "https://gd.image-gmkt.com/li/143/151/648151143.g_520-w_g.jpg", productData: { productName: "해피퍼킹 키보드", productDiscountRate:0, productBasePrice: 0, productPrice:0}},
+]
+
+const MainPage = () => (
+  <>
+    <HorizontalBar start='아이콘(<-)' center='로고(B마트)' end='아이콘(햄버거)' />
+    <PullToRefresh/>
+    <Carousel promotionImgData={promotionImgData}/>
+    <MainCategorySet />
+    <HorizontalCardSet data={data}/>
+    <ShowcaseCardSet/>
+    <Carousel promotionImgData={promotionImgData}/>
+    <GridCardSet/>
+    <HorizontalCardSet data={data}/>
+    <HorizontalCardSet data={data}/>
+    <Carousel promotionImgData={promotionImgData}/>
+    <CardSetWithCategory/>
+    <MainFooter/>
+  </>
+);
+
+export default MainPage;


### PR DESCRIPTION
- 작업 내용
  - 이슈(#57 Main Page) 등록(필요한 최상위 컴포넌트 명세)
  - 메인페이지 생성
  - 컴포넌트 폴더 생성 -> 메인페이지에 추가

<br />

- 이후 작업할 내용
  - Context Api 적용하여 데이터 fetching(더미데이터 삭제)
  - 메인페이지에 들어갈 컴포넌트 만들기