### PR TITLE
Feat/61/main skeleton

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -17,8 +17,9 @@
   },
   "scripts": {
     "dev": "next -p 9000",
-    "start": "next start",
-    "build": "next build",
+    "start": "next start -p 9000",
+    "build": "next build ",
+    "postbuild": "next export && rm -rf ../server/public && mv out ../server/public",
     "test": "react-scripts test",
     "eject": "react-scripts eject"
   },

--- a/client/scripts/create_context.sh
+++ b/client/scripts/create_context.sh
@@ -48,9 +48,9 @@ const ${FILE_NAME}Reducer = (
 ): ${FILE_NAME}State => {
 	switch (action.type) {
 		case 'ACTION_NAME':
-			return state; // new state
+			return state;
 		default:
-			throw new Error('Unhandled action');
+			throw new Error('존재하지 않는 액션입니다.');
 	}
 };
 
@@ -59,6 +59,6 @@ const initial${FILE_NAME}: ${FILE_NAME}State = 0;
 export const {
 	ContextProvider: ${FILE_NAME}Provider,
 	Contexts: ${FILE_NAME}Contexts,
-} = contextCreator<CounterState, CounterAction>(CounterReducer, initialCounter);
+} = contextCreator<${FILE_NAME}State, ${FILE_NAME}Action>(${FILE_NAME}Reducer, initial${FILE_NAME});
 
 " > src/${CONTEXT_FOLDER}/${FILE_NAME}Context.tsx`

--- a/client/src/api/bmart.ts
+++ b/client/src/api/bmart.ts
@@ -1,7 +1,6 @@
 import Axios from 'axios';
 
-const TOKEN_KEY = 'TOKEN';
-
+export const TOKEN_KEY = 'X-Auth';
 export type MethodType = 'GET' | 'POST' | 'DELETE' | 'PATCH' | 'PUT';
 
 const devURL = 'http://localhost:3000';
@@ -15,10 +14,11 @@ export const bmart = Axios.create({
   headers: { 'Content-Type': 'application/json' },
 });
 
-// export const bmartAuth = Axios.create({
-//   baseURL: baseURL,
-//   headers: {
-//     'Content-Type': 'application/json',
-//     [TOKEN_KEY]: localStorage.getItem(TOKEN_KEY),
-//   },
-// });
+export const bmartAuth = (token: string) =>
+  Axios.create({
+    baseURL: baseURL,
+    headers: {
+      'Content-Type': 'application/json',
+      [TOKEN_KEY]: token,
+    },
+  });

--- a/client/src/api/image.ts
+++ b/client/src/api/image.ts
@@ -1,0 +1,7 @@
+import { bmart } from './bmart';
+import { Image } from '../../../shared';
+
+export const getBannersImage = async () => {
+  const { data } = await bmart.get<Image[]>('/image/banner');
+  return data;
+};

--- a/client/src/api/index.ts
+++ b/client/src/api/index.ts
@@ -1,3 +1,5 @@
-//export * from './user';
+export * from './bmart';
+export * from './user';
 export * from './category';
 export * from './product';
+export * from './image';

--- a/client/src/api/user.ts
+++ b/client/src/api/user.ts
@@ -1,0 +1,8 @@
+import { bmart, bmartAuth } from './bmart';
+import { User } from '../../../shared';
+
+export const getCurrentUser = async (token: string) => {
+  const { data } = await bmartAuth(token).get<User>('/auth/current-user');
+
+  return data;
+};

--- a/client/src/components/Carousel/Carousel.tsx
+++ b/client/src/components/Carousel/Carousel.tsx
@@ -2,20 +2,25 @@ import React from 'react';
 import * as S from './CarouselStyle';
 
 export type PromotionImgDataProps = {
-	id: number
-	imgSrc: string
-}
+  promotionImgData: {
+    id: number;
+    imgSrc: string;
+  }[];
+};
 
-const Carousel: React.FC<PromotionImgDataProps> = ({ promotionImgData } : PromotionImgDataProps) => {
-	const length: number = promotionImgData.length;
+const Carousel: React.FC<PromotionImgDataProps> = ({
+  promotionImgData,
+}: PromotionImgDataProps) => {
+  const length: number = promotionImgData.length;
 
-	return (
-	<S.Container>
-		{promotionImgData.map(img => <S.Img key={img.id} length={length} src={img.imgSrc}/>)}
-		<S.Img length={length} src={promotionImgData[0].imgSrc}/>
-	</S.Container>
-	)
+  return (
+    <S.Container>
+      {promotionImgData.map((img) => (
+        <S.Img key={img.id} length={length} src={img.imgSrc} />
+      ))}
+      <S.Img length={length} src={promotionImgData[0].imgSrc} />
+    </S.Container>
+  );
 };
 
 export default Carousel;
-

--- a/client/src/components/HorizontalCardSet/HorizontalCardSet.tsx
+++ b/client/src/components/HorizontalCardSet/HorizontalCardSet.tsx
@@ -1,15 +1,14 @@
 import React from 'react';
 import * as S from './HorizontalCardSetStyle';
-import { CardProps } from './../Card/Card'
-import { Card } from './../Card'
+import { CardProps } from './../Card/Card';
+import { Card } from './../Card';
 
-const HorizontalCardSet: React.FC<CardProps> = ( { data }  : CardProps) => {
-
-	return (
-	<S.Container>
-		{data.map(product => <Card key={product.id} {...product}/>)}
-	</S.Container>
-	);
+const HorizontalCardSet: React.FC<CardProps> = ({}: CardProps) => {
+  return (
+    <S.Container>
+      {/* {data.map(product => <Card key={product.id} {...product}/>)} */}
+    </S.Container>
+  );
 };
 
 export default HorizontalCardSet;

--- a/client/src/components/SideMenu/SideMenu.tsx
+++ b/client/src/components/SideMenu/SideMenu.tsx
@@ -2,16 +2,16 @@ import React from 'react';
 import * as S from './SideMenuStyle';
 
 type Props = {
-	open: boolean;
-}
+  open: boolean;
+  setOpen: React.Dispatch<React.SetStateAction<boolean>>;
+};
 
-const SideMenu: React.FC<Props> = ({ open, setOpen } : Props) => {
-
-	return (
-		<S.Container open={open}> 
-			<S.Icon open={open} onClick={() => setOpen(!open)}>X</S.Icon>
-		</S.Container>
-	)
+const SideMenu: React.FC<Props> = ({ open, setOpen }: Props) => {
+  return (
+    <S.Container open={open}>
+      <S.Icon onClick={() => setOpen(!open)}>X</S.Icon>
+    </S.Container>
+  );
 };
 
 export default SideMenu;

--- a/client/src/context/CategoryContext.tsx
+++ b/client/src/context/CategoryContext.tsx
@@ -1,6 +1,10 @@
-import React from 'react';
 import { contextCreator } from '../utils/createContext';
-import { Category } from '../../../shared';
+// import { Category } from '../../../shared';
+export type Category = {
+  id: number;
+  name: string;
+  subCategory?: Category[];
+};
 
 export type CategoryState = Category[] | null;
 

--- a/client/src/context/UserContext.tsx
+++ b/client/src/context/UserContext.tsx
@@ -1,0 +1,23 @@
+import { contextCreator } from '../utils/createContext';
+
+import { User } from '../../../shared';
+
+export type UserState = User | null;
+
+export type UserAction = { type: 'SET_USER'; user: User | null };
+
+const UserReducer = (state: UserState, action: UserAction): UserState => {
+  switch (action.type) {
+    case 'SET_USER':
+      return action.user;
+    default:
+      throw new Error('존재하지 않는 액션입니다.');
+  }
+};
+
+const initialUser: UserState = null;
+
+export const {
+  ContextProvider: UserProvider,
+  Contexts: UserContexts,
+} = contextCreator<UserState, UserAction>(UserReducer, initialUser);

--- a/client/src/context/index.tsx
+++ b/client/src/context/index.tsx
@@ -2,9 +2,11 @@ import { CombineProviderApp } from '../utils/createContext';
 import { CounterProvider } from '../context/CounterContext';
 import { CategoryProvider } from '../context/CategoryContext';
 import { ProductProvider } from '../context/ProductContext';
+import { UserProvider } from './UserContext';
 
 export const CombinedProviders = CombineProviderApp(
   CounterProvider,
   CategoryProvider,
-  ProductProvider
+  ProductProvider,
+  UserProvider
 );

--- a/client/src/hooks/useCategory.tsx
+++ b/client/src/hooks/useCategory.tsx
@@ -1,21 +1,20 @@
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 import { useCreator } from '../utils/createContext';
 import { CategoryContexts } from '../context/CategoryContext';
 import { Category } from '../../../shared';
-import { fetchCategory } from '../api';
 
 export const useCategory = (categories?: Category[]) => {
   const [category, dispatch] = useCreator(CategoryContexts);
 
   useEffect(() => {
     if (categories) {
-      setCategory(categories);
+      dispatch({ type: 'FETCH_CATEGORY', categories });
     }
-  }, [categories]);
+  }, [categories, dispatch]);
 
-  const setCategory = async (categories: Category[]) => {
-    dispatch({ type: 'FETCH_CATEGORY', categories });
-  };
+  // const setCategory = async (categories: Category[]) => {
+  //   dispatch({ type: 'FETCH_CATEGORY', categories });
+  // };
 
   return { category };
 

--- a/client/src/hooks/useUser.tsx
+++ b/client/src/hooks/useUser.tsx
@@ -1,0 +1,26 @@
+import { useCreator } from '../utils/createContext';
+import { UserContexts } from '../context/UserContext';
+import { TOKEN_KEY, getCurrentUser } from '../api';
+
+export const useUser = () => {
+  const [user, dispatch] = useCreator(UserContexts);
+
+  const signIn = async (token: string) => {
+    const user = await getCurrentUser(token);
+    dispatch({ type: 'SET_USER', user });
+  };
+
+  const signOut = () => {
+    localStorage.removeItem(TOKEN_KEY);
+    dispatch({ type: 'SET_USER', user: null });
+  };
+
+  const isLoggedIn = user ? true : false;
+
+  return { isLoggedIn, user, signIn, signOut };
+
+  // or make custom action creator
+  // const doSomething = () => dispatch({type : 'DO_SOMETHING'})
+
+  // return { user, doSomething };
+};

--- a/client/src/pages/_app.tsx
+++ b/client/src/pages/_app.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React from 'react';
 import App, { AppProps, AppContext } from 'next/app';
 import GlobalStyle from '../styles/GlobalStyle';
 import { CombinedProviders } from '../context';
@@ -12,11 +12,9 @@ type InitialProps = {
 let IS_INITIALIZED = false;
 
 const InitializeStore: React.FC<InitialProps> = ({ children, category }) => {
-  if (!IS_INITIALIZED) {
-    useCategory(category);
+  useCategory(category);
 
-    IS_INITIALIZED = true;
-  }
+  IS_INITIALIZED = true;
   return <>{children}</>;
 };
 

--- a/client/src/pages/_document.tsx
+++ b/client/src/pages/_document.tsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import Document, { DocumentContext } from 'next/document';
 import { ServerStyleSheet } from 'styled-components';
 

--- a/client/src/pages/auth/[token].tsx
+++ b/client/src/pages/auth/[token].tsx
@@ -1,0 +1,26 @@
+import React, { useEffect } from 'react';
+import { useRouter } from 'next/router';
+import { useUser } from '../../hooks/useUser';
+import { TOKEN_KEY } from '../../api';
+
+const AuthPage = () => {
+  const router = useRouter();
+  const { token } = router.query;
+  const { signIn } = useUser();
+
+  useEffect(() => {
+    singInWithToken();
+  }, [token, router]);
+
+  const singInWithToken = async () => {
+    if (token && typeof token === 'string') {
+      localStorage.setItem(TOKEN_KEY, token);
+      await signIn(token);
+      router.push('/');
+    }
+  };
+
+  return <p>Logged In</p>;
+};
+
+export default AuthPage;

--- a/client/src/pages/index.tsx
+++ b/client/src/pages/index.tsx
@@ -1,29 +1,32 @@
 import React from 'react';
 import Link from 'next/link';
+import { InferGetServerSidePropsType } from 'next';
+import { getBannersImage } from '../api';
+import { Carousel } from '../components/Carousel';
 
-const IndexPage = () => {
+const IndexPage = ({
+  bannerImages,
+}: InferGetServerSidePropsType<typeof getServerSideProps>) => {
   return (
     <>
-      <h1> helle bmart - 9</h1>
-      <Link href="/counter">
-        <a>go to counter</a>
-      </Link>
-      <br />
-      <Link href="/card">
-        <a>go to card</a>
-      </Link>
-      <br />
-      <Link href="/admin_chano">
-        <a>go to cnAdmin</a>
-      </Link>
-      <Link href="/admin_bg">
-        <a>go to admin bongeun</a>
-      </Link>
-      <Link href="/admin_andy">
-        <a>go to admin andy</a>
-      </Link>
+      <img src={bannerImages[0].img} />
+      {/* <Carousel images={bannerImages}/> */}
+      {/* <CategoryContainer image={categoryIamges}/> */}
     </>
   );
+};
+
+export const getServerSideProps = async () => {
+  const bannerImages = await getBannersImage();
+  // const categoryIamges = await getCategoryImage();
+  // const res = await fetch('https://.../data');
+  // const data: Data = await res.json();
+  return {
+    props: {
+      bannerImages,
+      // categoryIamges
+    },
+  };
 };
 
 export default IndexPage;

--- a/server/.gitignore
+++ b/server/.gitignore
@@ -2,3 +2,6 @@ node_modules
 
 .env
 .env.*
+
+dist
+public

--- a/server/package.json
+++ b/server/package.json
@@ -6,9 +6,10 @@
   "scripts": {
     "test": "jest --watchAll --runInBand --detectOpenHandles",
     "dev": "NODE_ENV=development ts-node-dev --respawn --transpile-only src/index.ts",
-    "build:client": "cd ../client && npm run build",
     "build": "tsc",
-    "start": "NODE_ENV=production pm2 start dist/index.js"
+    "postbuild": "cd ../client && npm run build",
+    "start": "NODE_ENV=production pm2 start dist/server/src/index.js",
+    "ts": "node dist/server/src/index.js"
   },
   "keywords": [],
   "author": "",

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -1,6 +1,6 @@
 import dotenv from 'dotenv';
 dotenv.config();
-import express, { Request, Response, NextFunction } from 'express';
+import express from 'express';
 
 import bodyParser from 'body-parser';
 import path from 'path';
@@ -29,9 +29,12 @@ app.use(router);
 
 app.use(errorHandler);
 
+app.get('/auth/:token', (req, res) => {
+  res.sendFile(path.join(__dirname, '../public/auth/[token].html'));
+});
+
 app.get('/*', (req, res) => {
-  res.send('');
-  // res.sendFile(path.join(__dirname, '../public/index.html'));
+  res.sendFile(path.join(__dirname, '../public/index.html'));
 });
 
 export default app;

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -1,5 +1,4 @@
 import app from './app';
-import { baseUrl } from './urlConfig';
-const PORT = 3000;
+import { baseUrl, PORT } from './urlConfig';
 
-app.listen(PORT, () => console.log(`connected to ${baseUrl}:${PORT}`));
+app.listen(PORT, () => console.log(`connected to ${baseUrl}`));

--- a/server/src/middlewares/decode-jwt.ts
+++ b/server/src/middlewares/decode-jwt.ts
@@ -2,12 +2,14 @@ import { Request, Response, NextFunction } from 'express';
 import { verifyJWT } from '../utils/jwt';
 import { AuthenticateError } from '../errors/authenticate-error';
 
+export const TOKEN_KEY = 'x-auth';
+
 export const decodeJWT = async (
   req: Request,
   res: Response,
   next: NextFunction
 ) => {
-  const token = req.headers.token;
+  const token = req.headers[TOKEN_KEY];
 
   if (token) {
     const user = await verifyJWT(token as string);

--- a/server/src/repository/image-repository.ts
+++ b/server/src/repository/image-repository.ts
@@ -1,0 +1,19 @@
+import { selectQueryExecuter } from '../utils/query-executor';
+import { Image } from '../../../shared';
+
+export class ImageRepo {
+  static async selectAllBanners() {
+    const selectAllBannersQuery = `
+      SELECT
+        *
+      FROM
+        banner
+    `;
+
+    // type generic
+    const allBannerImages = await selectQueryExecuter<Image>(
+      selectAllBannersQuery
+    );
+    return allBannerImages;
+  }
+}

--- a/server/src/repository/user-repository.ts
+++ b/server/src/repository/user-repository.ts
@@ -2,18 +2,14 @@ import {
   insertQueryExecuter,
   selectQueryExecuter,
 } from '../utils/query-executor';
+import { User } from '../../../shared';
 
 export type SocialSignUpBody = {
   name: string;
   socialId: string;
 };
 
-export type UserType = {
-  id: number;
-  name: string;
-};
-
-export class User {
+export class UserRepo {
   static async createWithSocial({ socialId, name }: SocialSignUpBody) {
     const createNewUserQuery = `
       INSERT INTO
@@ -25,7 +21,7 @@ export class User {
     return await insertQueryExecuter(createNewUserQuery);
   }
 
-  static async findOne(id: number): Promise<UserType> {
+  static async findOne(id: number): Promise<User> {
     const findOneUserQuery = `
       SELECT
         id, name
@@ -35,11 +31,11 @@ export class User {
         id=${id}
     `;
 
-    const [user, _] = await selectQueryExecuter<UserType>(findOneUserQuery);
+    const [user, _] = await selectQueryExecuter<User>(findOneUserQuery);
     return user;
   }
 
-  static async findBySocialId(socialId: number): Promise<UserType> {
+  static async findBySocialId(socialId: number): Promise<User> {
     const findOneUserQuery = `
       SELECT
         id, name
@@ -49,7 +45,7 @@ export class User {
         social_id=${socialId}
     `;
 
-    const [user, _] = await selectQueryExecuter<UserType>(findOneUserQuery);
+    const [user, _] = await selectQueryExecuter<User>(findOneUserQuery);
     return user;
   }
 }

--- a/server/src/routes/image-routes.ts
+++ b/server/src/routes/image-routes.ts
@@ -1,0 +1,7 @@
+import { Router } from 'express';
+import { getBannerImage } from '../service/image-service';
+const router = Router();
+
+router.get('/banner', getBannerImage);
+
+export default router;

--- a/server/src/routes/index.ts
+++ b/server/src/routes/index.ts
@@ -2,11 +2,13 @@ import { Router } from 'express';
 import authRouter from './auth-routes';
 import categoryRouter from './category-routes';
 import productRouter from './product-routes';
+import imageRouter from './image-routes';
 
 const router = Router({});
 
 router.use('/api/auth', authRouter);
 router.use('/api/category', categoryRouter);
 router.use('/api/product', productRouter);
+router.use('/api/image', imageRouter);
 
 export default router;

--- a/server/src/service/auth-service.ts
+++ b/server/src/service/auth-service.ts
@@ -7,7 +7,7 @@ declare global {
 }
 
 export const socialSignIn = async (req: Request, res: Response) => {
-  res.json('');
+  res.redirect(`/auth/${req.authInfo}`);
 };
 
 export const getCurrentUser = async (req: Request, res: Response) => {

--- a/server/src/service/image-service.ts
+++ b/server/src/service/image-service.ts
@@ -1,0 +1,8 @@
+import { Request, Response } from 'express';
+import { ImageRepo } from '../repository/image-repository';
+
+export const getBannerImage = async (req: Request, res: Response) => {
+  const allBannerImages = await ImageRepo.selectAllBanners();
+
+  res.json(allBannerImages);
+};

--- a/server/src/urlConfig.ts
+++ b/server/src/urlConfig.ts
@@ -1,5 +1,7 @@
-const devUrl = 'http://localhost:3000';
+export const PORT = 3000;
+
+const devUrl = 'http://localhost:';
 // TODO
-const prodUrl = 'http://localhost:3000';
+const prodUrl = `http://${process.env.DB_HOST}:`;
 export const baseUrl =
-  process.env.NODE_MODE === 'production' ? prodUrl : devUrl;
+  (process.env.NODE_MODE === 'production' ? prodUrl : devUrl) + PORT;

--- a/server/src/utils/jwt.ts
+++ b/server/src/utils/jwt.ts
@@ -1,16 +1,17 @@
 import jwt from 'jsonwebtoken';
-import { UserType, User } from '../repository/user-repository';
+import { UserRepo } from '../repository/user-repository';
+import { User } from '../../../shared';
 
 export const createJWT = (id: number): string => {
   return jwt.sign({ id }, process.env.JWT_TOKEN || '');
 };
 
-export const verifyJWT = async (token: string): Promise<UserType | null> => {
+export const verifyJWT = async (token: string): Promise<User | null> => {
   const verifyResult: any = jwt.verify(token, process.env.JWT_TOKEN || '');
   if (!verifyResult) {
     return null;
   }
 
   const { id } = verifyResult;
-  return await User.findOne(id);
+  return await UserRepo.findOne(id);
 };

--- a/server/src/utils/passport.ts
+++ b/server/src/utils/passport.ts
@@ -1,6 +1,6 @@
 import passport from 'passport';
 import { Strategy as GitHubStrategy } from 'passport-github';
-import { User } from '../repository/user-repository';
+import { UserRepo } from '../repository/user-repository';
 import { createJWT } from './jwt';
 import { baseUrl } from '../urlConfig';
 
@@ -12,13 +12,13 @@ passport.use(
       callbackURL: `${baseUrl}/api/auth/github/callback`,
     },
     async (_, __, profile, cb) => {
-      const existedUser = await User.findBySocialId(profile.id);
+      const existedUser = await UserRepo.findBySocialId(profile.id);
       if (existedUser) {
         const token = await createJWT(existedUser.id);
-        return cb(null, null, token);
+        return cb(null, token, token);
       }
 
-      const [createUserId, error] = await User.createWithSocial({
+      const createUserId = await UserRepo.createWithSocial({
         socialId: profile.id,
         name: profile.displayName,
       });

--- a/shared/image.ts
+++ b/shared/image.ts
@@ -1,0 +1,5 @@
+export type Image = {
+  id: number;
+  name: string;
+  img: string;
+};

--- a/shared/index.ts
+++ b/shared/index.ts
@@ -1,2 +1,4 @@
+export * from "./user";
 export * from "./category";
 export * from "./product";
+export * from "./image";

--- a/shared/product.ts
+++ b/shared/product.ts
@@ -1,24 +1,22 @@
-
 export type Product = {
-	id: number;
-	name: string;
-	image: string;
-	price: number;
-	discount: number;
-	basePrice: number;
-	category2Id: number;
-	stock: number;
+  id: number;
+  name: string;
+  image: string;
+  price: number;
+  discount: number;
+  basePrice: number;
+  category2Id: number;
+  stock: number;
 };
 
 export type CreateProductBody = {
-	name: string;
-	image: string;
-	price: number;
-	basePrice?: number;
-	discount?: number;
-	createdAt?: string;
-	updatedAt?: string;
-	category2Id: number;
-	stock: number;
+  name: string;
+  image: string;
+  price: number;
+  basePrice?: number;
+  discount?: number;
+  createdAt?: string;
+  updatedAt?: string;
+  category2Id: number;
+  stock: number;
 };
-

--- a/shared/user.ts
+++ b/shared/user.ts
@@ -1,0 +1,4 @@
+export type User = {
+  id: number;
+  name: string;
+};


### PR DESCRIPTION
## Skeleton Structure for Main page

옵저버의 기량 만개를 위하여 Main page를 만들기 위한 프론트부터 백까지의 전체적인 라이브코딩 결과를 담은 스켈레톤 구조를 공유합니다.

## client
- pages/index.tsx -> `/` route를 담당하는 메인 페이지, getServerSideProps를 통해 서버에서 여러 데이터를 받아와서 해당 페이지에 렌더해야함
- api/images.ts -> 서버에서 데이터를 가져오는 ajax 콜을 관리하는 파일들

## server
- image-routes : image 관련 REST API 핸들링
- image-service : image 관련 비지니스 로직 핸들링
- image-repository : image 관련 데이터베이스 핸들링

@jungcome7 의 기량이 만개하길 바랍니다 adidas

Resolve #61 