### PR TITLE
Feat/57/카테고리 컨테이너 컴포넌트 생성 및 배치

### DIFF
--- a/client/src/api/image.ts
+++ b/client/src/api/image.ts
@@ -5,3 +5,8 @@ export const getBannersImage = async () => {
   const { data } = await bmart.get<Image[]>('/image/banner');
   return data;
 };
+
+export const getIconsImage = async () => {
+  const { data } = await bmart.get<Image[]>('/image/icon');
+  return data;
+};

--- a/client/src/api/image.ts
+++ b/client/src/api/image.ts
@@ -6,7 +6,7 @@ export const getBannersImage = async () => {
   return data;
 };
 
-export const getIconsImage = async () => {
-  const { data } = await bmart.get<Image[]>('/image/icon');
+export const getCategoryIcons = async () => {
+  const { data } = await bmart.get<Image[]>('/image/category-icon');
   return data;
 };

--- a/client/src/components/CategoryContainer/CategoryContainer.tsx
+++ b/client/src/components/CategoryContainer/CategoryContainer.tsx
@@ -3,14 +3,16 @@ import * as S from './CategoryContainerStyle';
 import { Image } from './../../../../shared';
 
 type CategoryProps = {
-	iconImages: Image[];
+	categoryIcons: Image[];
 }
 
-const CategoryContainer: React.FC<CategoryProps> = ({ iconImages } : CategoryProps) => {
+const CategoryContainer: React.FC<CategoryProps> = ({ categoryIcons } : CategoryProps) => {
 
 	return (
 		<S.Container>
-			<S.Category src={iconImages[0].img}/>
+			{categoryIcons.map((item) => (
+        <S.Category key={item.id} src={item.img} name={item.name} />
+      ))}
 		</S.Container>
 	)
 };

--- a/client/src/components/CategoryContainer/CategoryContainer.tsx
+++ b/client/src/components/CategoryContainer/CategoryContainer.tsx
@@ -1,11 +1,18 @@
 import React from 'react';
 import * as S from './CategoryContainerStyle';
+import { Image } from './../../../../shared';
 
-type Props = {}
+type CategoryProps = {
+	iconImages: Image[];
+}
 
-const CategoryContainer: React.FC<Props> = ({} : Props) => {
+const CategoryContainer: React.FC<CategoryProps> = ({ iconImages } : CategoryProps) => {
 
-	return <S.Container>CategoryContainer</S.Container>;
+	return (
+		<S.Container>
+			<S.Category src={iconImages[0].img}/>
+		</S.Container>
+	)
 };
 
 export default CategoryContainer;

--- a/client/src/components/CategoryContainer/CategoryContainerStyle.ts
+++ b/client/src/components/CategoryContainer/CategoryContainerStyle.ts
@@ -13,6 +13,7 @@ type ImgProps = {
 };
 
 export const Category = styled.img<ImgProps>`
+  name: 
   display: inline-block;
   width: 20vw;
   padding: 5px;

--- a/client/src/components/CategoryContainer/CategoryContainerStyle.ts
+++ b/client/src/components/CategoryContainer/CategoryContainerStyle.ts
@@ -3,7 +3,9 @@ import styled from 'styled-components';
 export const Container = styled.div`
   width: 100vw;
   height: 30vh;
-  background-color: grey;
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
 `
 
 type ImgProps = {
@@ -13,6 +15,5 @@ type ImgProps = {
 export const Category = styled.img<ImgProps>`
   display: inline-block;
   width: 20vw;
-  height: 14vh;
-  margin-top: 5px;
+  padding: 5px;
 `;

--- a/client/src/components/CategoryContainer/CategoryContainerStyle.ts
+++ b/client/src/components/CategoryContainer/CategoryContainerStyle.ts
@@ -6,7 +6,13 @@ export const Container = styled.div`
   background-color: grey;
 `
 
-export const Category = styled.img`
-  width: 100%;
-  height: 100%;
-`
+type ImgProps = {
+  name: string;
+};
+
+export const Category = styled.img<ImgProps>`
+  display: inline-block;
+  width: 20vw;
+  height: 14vh;
+  margin-top: 5px;
+`;

--- a/client/src/components/CategoryContainer/CategoryContainerStyle.ts
+++ b/client/src/components/CategoryContainer/CategoryContainerStyle.ts
@@ -1,4 +1,12 @@
 import styled from 'styled-components';
 
-export const Container = styled.div``
+export const Container = styled.div`
+  width: 100vw;
+  height: 30vh;
+  background-color: grey;
+`
 
+export const Category = styled.img`
+  width: 100%;
+  height: 100%;
+`

--- a/client/src/pages/index.tsx
+++ b/client/src/pages/index.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import Link from 'next/link';
 import { InferGetStaticPropsType } from 'next';
 import { getBannersImage } from '../api';
+import { getIconsImage } from '../api';
 import { Carousel } from '../components/Carousel';
 import { HorizontalBar } from '../components/HorizontalBar';
 import { CategoryContainer } from '../components/CategoryContainer';
@@ -13,16 +14,18 @@ const IndexPage = ({
     <>
       <HorizontalBar start='아이콘' center='로고' end='아이콘'/>
       <Carousel bannerImages={bannerImages}/>
-      <CategoryContainer/>
+      <CategoryContainer iconImages={iconImages}/>
     </>
   );
 };
 
 export const getStaticProps = async () => {
   const bannerImages = await getBannersImage();
+  const iconImages = await getIconsImage();
   return {
     props: {
       bannerImages,
+      iconImages,
     },
   };
 };

--- a/client/src/pages/index.tsx
+++ b/client/src/pages/index.tsx
@@ -2,30 +2,31 @@ import React from 'react';
 import Link from 'next/link';
 import { InferGetStaticPropsType } from 'next';
 import { getBannersImage } from '../api';
-import { getIconsImage } from '../api';
+import { getCategoryIcons } from '../api';
 import { Carousel } from '../components/Carousel';
 import { HorizontalBar } from '../components/HorizontalBar';
 import { CategoryContainer } from '../components/CategoryContainer';
 
 const IndexPage = ({
   bannerImages,
+  categoryIcons,
 }: InferGetStaticPropsType<typeof getStaticProps>) => {
   return (
     <>
       <HorizontalBar start='아이콘' center='로고' end='아이콘'/>
       <Carousel bannerImages={bannerImages}/>
-      <CategoryContainer iconImages={iconImages}/>
+      <CategoryContainer categoryIcons={categoryIcons}/>
     </>
   );
 };
 
 export const getStaticProps = async () => {
   const bannerImages = await getBannersImage();
-  const iconImages = await getIconsImage();
+  const categoryIcons = await getCategoryIcons();
   return {
     props: {
       bannerImages,
-      iconImages,
+      categoryIcons,
     },
   };
 };

--- a/server/src/repository/image-repository.ts
+++ b/server/src/repository/image-repository.ts
@@ -16,4 +16,21 @@ export class ImageRepo {
     );
     return allBannerImages;
   }
+
+  static async selectAllCategoryIcons() {
+    const selectAllCategoryIconsQuery = `
+      SELECT
+        *
+      FROM
+        icon
+      WHERE
+        name LIKE 'main%'
+    `;
+
+    // type generic
+    const allCategoryIcons = await selectQueryExecuter<Image>(
+      selectAllCategoryIconsQuery
+    );
+    return allCategoryIcons;
+  }
 }

--- a/server/src/routes/image-routes.ts
+++ b/server/src/routes/image-routes.ts
@@ -1,7 +1,9 @@
 import { Router } from 'express';
 import { getBannerImage } from '../service/image-service';
+import { getCategoryIconImage } from '../service/image-service';
 const router = Router();
 
 router.get('/banner', getBannerImage);
+router.get('/category-icon', getCategoryIconImage);
 
 export default router;

--- a/server/src/service/image-service.ts
+++ b/server/src/service/image-service.ts
@@ -6,3 +6,9 @@ export const getBannerImage = async (req: Request, res: Response) => {
 
   res.json(allBannerImages);
 };
+
+export const getCategoryIconImage = async (req: Request, res: Response) => {
+  const allCategoryIcons = await ImageRepo.selectAllCategoryIcons();
+
+  res.json(allCategoryIcons);
+};


### PR DESCRIPTION
### 요약
- category-icon API 생성
- 관련 쿼리 및 service 함수 생성
- CategoryContainer 컴포넌트 생성
- 메인페이지에 해당 컴포넌트 배치

### 개발 결과물
<kbd>
<img width="400" src="https://user-images.githubusercontent.com/34447105/90808895-b071d280-e35b-11ea-8056-d4a2dbb2ad9a.png" />
</kbd>

