### PR TITLE
Feat/86/category dynamic routing

### DIFF
--- a/client/src/api/category.ts
+++ b/client/src/api/category.ts
@@ -7,6 +7,13 @@ const getAll = async () => {
   return data;
 };
 
+const getOneByCategory2Id = async (category2Id: number) => {
+  const { data } = await bmart.get<Category>(`/category/${category2Id}`);
+
+  return data;
+};
+
 export default {
   getAll,
+  getOneByCategory2Id,
 };

--- a/client/src/components/BoxCategory/BoxCategory.tsx
+++ b/client/src/components/BoxCategory/BoxCategory.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import * as S from './BoxCategoryStyle';
 import { Category } from '../../../../shared';
 import { MainContainer } from '../MainContainer';
+import Link from 'next/link';
 
 type Props = {
   categories?: Category[];
@@ -12,7 +13,15 @@ const BoxCategory: React.FC<Props> = ({ categories }: Props) => {
     <MainContainer>
       <S.Container>
         {categories &&
-          categories.map((cate) => <S.Item key={cate.id}>{cate.name}</S.Item>)}
+          categories.map((cate) => (
+            <Link
+              key={cate.id}
+              href="/category/[id]"
+              as={`/category/${cate.id}`}
+            >
+              <S.Item>{cate.name}</S.Item>
+            </Link>
+          ))}
       </S.Container>
     </MainContainer>
   );

--- a/client/src/context/CategoryContext.tsx
+++ b/client/src/context/CategoryContext.tsx
@@ -6,7 +6,7 @@ export type Category = {
   subCategory?: Category[];
 };
 
-export type CategoryState = Category[] | null;
+export type CategoryState = Category[];
 
 export type CategoryAction = { type: 'FETCH_CATEGORY'; categories: Category[] };
 
@@ -22,7 +22,7 @@ const CategoryReducer = (
   }
 };
 
-const initialCategory: CategoryState = null;
+const initialCategory: CategoryState = [];
 
 export const {
   ContextProvider: CategoryProvider,

--- a/client/src/context/ProductContext.tsx
+++ b/client/src/context/ProductContext.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { contextCreator } from '../utils/createContext';
 import { Product } from '../../../shared/product';
 
-export type ProductState = Product[] | null;
+export type ProductState = Product[];
 
 export type ProductAction =
   | { type: 'ACTION_NAME' }
@@ -20,7 +20,7 @@ const ProductReducer = (
   }
 };
 
-const initialProduct: ProductState = null;
+const initialProduct: ProductState = [];
 
 export const {
   ContextProvider: ProductProvider,

--- a/client/src/pages/category/[id].tsx
+++ b/client/src/pages/category/[id].tsx
@@ -1,5 +1,6 @@
 import React, { useEffect } from 'react';
 import { useRouter } from 'next/router';
+import Router from 'next/router';
 import API from '../../api';
 import { useCategory } from '../../hooks/useCategory';
 import { useProduct } from '../../hooks/useProduct';
@@ -7,19 +8,21 @@ import { InferGetStaticPropsType, GetStaticPropsContext } from 'next';
 import { BoxCategory } from '../../components/BoxCategory';
 import { HorizontalBar } from '../../components/HorizontalBar';
 import { HorizontalSlider } from '../../components/HorizontalSlider';
+import category from '../../api/category';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faArrowLeft } from '@fortawesome/free-solid-svg-icons';
 
 const CategoryDetailPage = ({
-  greet,
+  categoryInfo,
 }: InferGetStaticPropsType<typeof getStaticProps>) => {
   const { query } = useRouter();
   const { category } = useCategory();
   const { getFilteredProductByCategory } = useProduct();
 
-  // TODO subcategory의 경우를 해결해야함
-  const currentCategory = category
-    ? category.find(({ id }) => query.id === id.toString())
-    : null;
-  const isSubCategory = currentCategory === null;
+  const currentCategory =
+    categoryInfo || category.find(({ id }) => query.id === id.toString());
+
+  const isSubCategory = categoryInfo ? true : false;
   const filteredProducts = getFilteredProductByCategory(
     +query.id,
     isSubCategory
@@ -31,10 +34,17 @@ const CategoryDetailPage = ({
 
   return (
     <>
-      <HorizontalBar center={currentCategory.name} start={'<'} end={'🔍'} />
-      {currentCategory.subCategory && (
-        <BoxCategory categories={currentCategory.subCategory} />
-      )}
+      <HorizontalBar
+        center={currentCategory.name}
+        start={
+          <FontAwesomeIcon
+            icon={faArrowLeft}
+            onClick={() => Router.back()}
+          ></FontAwesomeIcon>
+        }
+        end={'🔍'}
+      />
+      <BoxCategory categories={currentCategory.subCategory} />
       {filteredProducts && (
         <>
           <HorizontalSlider
@@ -58,28 +68,31 @@ const CategoryDetailPage = ({
 
 export const getStaticPaths = async () => {
   return {
-    paths: [
-      { params: { id: '420234' } },
-      { params: { id: '420376' } },
-      { params: { id: '435072' } },
-      { params: { id: '435052' } },
-      { params: { id: '464913' } },
-      { params: { id: '420388' } },
-      { params: { id: '420337' } },
-      { params: { id: '435052' } },
-      { params: { id: '420186' } },
-      { params: { id: '464911' } },
-    ],
+    paths: [],
     fallback: true,
   };
 };
 
 export const getStaticProps = async ({ params }: GetStaticPropsContext) => {
-  const products = await API.Product.getByCategory2Id(+(params!.id as string));
-  console.log('serverside: ', products);
+  const categoryInfo = await API.Category.getOneByCategory2Id(
+    Number(params!.id)
+  );
+
+  const res = Object.keys(categoryInfo).length === 0 ? null : categoryInfo;
   return {
-    props: { greet: 'hello' },
+    props: { categoryInfo: res },
   };
 };
 
 export default CategoryDetailPage;
+
+// { params: { id: '420234' } },
+// { params: { id: '420376' } },
+// { params: { id: '435072' } },
+// { params: { id: '435052' } },
+// { params: { id: '464913' } },
+// { params: { id: '420388' } },
+// { params: { id: '420337' } },
+// { params: { id: '435052' } },
+// { params: { id: '420186' } },
+// { params: { id: '464911' } },

--- a/server/src/routes/category-routes.ts
+++ b/server/src/routes/category-routes.ts
@@ -1,8 +1,9 @@
 import { Router } from 'express';
-import { getAllCategory } from '../service/category-service';
+import { getAllCategory, getCategoryInfo } from '../service/category-service';
 
 const router = Router();
 
 router.get('/', getAllCategory);
 
+router.get('/:id', getCategoryInfo);
 export default router;

--- a/server/src/service/category-service.ts
+++ b/server/src/service/category-service.ts
@@ -1,6 +1,7 @@
 import { Request, Response } from 'express';
 import { CategoryRepo } from '../repository/category-repository';
 import { Category } from '../../../shared';
+import { InvalidParamsError } from '../errors/invalid-params';
 
 export const getAllCategory = async (req: Request, res: Response) => {
   const allCategory = await CategoryRepo.selectAllCategory();
@@ -28,4 +29,15 @@ export const getAllCategory = async (req: Request, res: Response) => {
   }, []);
 
   res.json(category.slice(1));
+};
+
+export const getCategoryInfo = async (req: Request, res: Response) => {
+  const id = req.params.id;
+
+  if (!id) {
+    throw new InvalidParamsError('ID');
+  }
+
+  const categoryInfo = await CategoryRepo.findOne(+id);
+  res.json(categoryInfo);
 };


### PR DESCRIPTION
## Dynamic Routing
Next Js는 기본적으로 파일시스템을 이용해서 라우팅을 지원하는데, `category/[params].tsx|jsx` 형식으로 pages폴더 내부에 저장하면, `category/1`처럼 디테일한 다이나믹 라우팅을 지원해준다. 이를 세부적이게 이용하기 위해서는 몇 가지 디테일한 설정이 필요하다.

### getStaticPaths
라우팅을 핸들링 하기 위한 목적의 함수인데, `paths`와 `fallback`을 반드시 리턴해야 한다. 이때 블로그와 같은 스태틱한 서비스를 운영하고 있다면, paths에 특정한 url을 미리 설정해 둘 수 있다. 그렇게 되면 빌드하는 과정에서 해당 정보들을 미리 가져와서 로딩이 하나도 없는 페이지를 렌더할 수 있다. 그런 경우에는 보통 fallback을 false로 설정하는데, fallback은 지정하지 않은 주소 값에 대해 처리를 할 지에 대한 설정이다.

만약 fallback이 true로 설정되어 있다면, `category/*` 의 라우팅을 지원한다고 생각하면 편할 듯 하다. 이런 경우에는 빌드해서 미리 완성된 마크업을 제공할 수 없기 때문에, `next export` 명령어를 사용할 수 없다. 이런 경우를 위해서 `getStaticProps`와의 연계가 필요하다.

### getStaticProps
URL의 parmas가 어떤 값이 들어올지 모르는 상황이라면, 각각의 라우팅된 페이지에서 필요한 데이터를 가져와서 렌더링 해야하는데, 필요한 데이터를 가져오는 부분이 바로 이 함수다. 미리 데이터를 가져오고, 페이지의 props형태로 데이터를 내려보내주는 SSR을 지원한다. 다이나믹 라우팅 환경에서는 `getServerSideProps` 함수보다는 이 함수가 주로 쓰인다고 한다. 또한 `getStaticPaths`와의 조합도 훌륭해서 둘 중 하나가 없으면 일단 에러를 내 뱉어준다. 


### 대분류 카테고리
<p align="center">
  <img src="https://user-images.githubusercontent.com/30615804/91026853-4ba5c900-e636-11ea-8bed-e4f3429fc9da.png" width="200" />
<img src="https://user-images.githubusercontent.com/30615804/91026936-68420100-e636-11ea-99d8-0d51c7b07712.png" width="200" />
</p>
대분류 카테고리에 들어갔을 땐 소분류로 들어갈 수 있는 라우팅이 지원되며, 소분류 카테고리로 들어왔을 때는 더 이상의 라우팅은 지원하지 않는다.

## nullable to non-null
context API의 초기 값을 설정하는 과정에서 ` | null` 타입으로 설정하여, 초기에 nullable하게 만들었더니 여러곳에서 문제들이 발생하여, 현재는 기본 타입에 맞는 형태로 초기값을 설정했다. Product[]와 같은 타입에는 그냥 [] 으로 설정했다. 

## 참고자료
- https://nextjs.org/docs/routing/dynamic-routes
- https://nextjs.org/docs/basic-features/data-fetching
- https://github.com/vercel/next.js/blob/canary/examples/catch-all-routes/components/header.js
Resolve #86 