### PR TITLE
Feat/27/ 6카드 컨테이너 컴포넌트 생성

### DIFF
--- a/client/src/components/Card/Card.tsx
+++ b/client/src/components/Card/Card.tsx
@@ -4,12 +4,17 @@ import { CardImg } from './../CardImg';
 import { CardContent } from './../CardContent';
 import { Product } from '../../../../shared';
 
-const Card: React.FC<Product> = (product: Product) => {
+type CardProps = {
+  width: number;
+  product: Product;
+};
+
+const Card: React.FC<CardProps> = ({ width, product }: CardProps) => {
   const { img } = product;
 
   return (
-    <S.Container>
-      <CardImg imgSrc={img} />
+    <S.Container width={width}>
+      <CardImg imgSrc={img} width={width}/>
       <CardContent {...product} />
     </S.Container>
   );

--- a/client/src/components/Card/Card.tsx
+++ b/client/src/components/Card/Card.tsx
@@ -5,16 +5,16 @@ import { CardContent } from './../CardContent';
 import { Product } from '../../../../shared';
 
 type CardProps = {
-  width: number;
+  viewportWidth: number;
   product: Product;
 };
 
-const Card: React.FC<CardProps> = ({ width, product }: CardProps) => {
+const Card: React.FC<CardProps> = ({ viewportWidth, product }: CardProps) => {
   const { img } = product;
 
   return (
-    <S.Container width={width}>
-      <CardImg imgSrc={img} width={width}/>
+    <S.Container viewportWidth={viewportWidth}>
+      <CardImg imgSrc={img} viewportWidth={viewportWidth}/>
       <CardContent {...product} />
     </S.Container>
   );

--- a/client/src/components/Card/CardStyle.ts
+++ b/client/src/components/Card/CardStyle.ts
@@ -1,11 +1,11 @@
 import styled from 'styled-components';
 
 type CardContainerProps = {
-  width: number;
+  viewportWidth: number;
 };
 
 export const Container = styled.div<CardContainerProps>`
   display: inline-block;
-  width: ${(props) => `${props.width}vw`};
+  width: ${(props) => `${props.viewportWidth}vw`};
   vertical-align: top;
 `;

--- a/client/src/components/Card/CardStyle.ts
+++ b/client/src/components/Card/CardStyle.ts
@@ -1,9 +1,11 @@
 import styled from 'styled-components';
 
-export const Container = styled.div`
-  display: inline-block;
-  width: 150px;
-  /* height: 150px; */
-  vertical-align:top;
-`
+type CardContainerProps = {
+  width: number;
+};
 
+export const Container = styled.div<CardContainerProps>`
+  display: inline-block;
+  width: ${(props) => `${props.width}vw`};
+  vertical-align: top;
+`;

--- a/client/src/components/CardContent/CardContent.tsx
+++ b/client/src/components/CardContent/CardContent.tsx
@@ -16,7 +16,7 @@ export const CardContent: React.FC<Product> = ({
   return (
     <>
       <S.Container>
-        <S.ProductName>{name.substring(0, 22)}</S.ProductName>
+        <S.ProductName>{name}</S.ProductName>
           {discount ? <S.ProductDiscount>{discount}%</S.ProductDiscount> : ''}
           {base_price ? <S.ProductBasePrice>{numberComma(base_price)}원</S.ProductBasePrice> : ''}
           <S.ProductPrice>{numberComma(price)}원</S.ProductPrice>

--- a/client/src/components/CardContent/CardContent.tsx
+++ b/client/src/components/CardContent/CardContent.tsx
@@ -16,7 +16,7 @@ export const CardContent: React.FC<Product> = ({
   return (
     <>
       <S.Container>
-        <S.ProductName>{name}</S.ProductName>
+        <S.ProductName>{name.substring(0, 22)}</S.ProductName>
           {discount ? <S.ProductDiscount>{discount}%</S.ProductDiscount> : ''}
           {base_price ? <S.ProductBasePrice>{numberComma(base_price)}원</S.ProductBasePrice> : ''}
           <S.ProductPrice>{numberComma(price)}원</S.ProductPrice>

--- a/client/src/components/CardImg/CardImg.tsx
+++ b/client/src/components/CardImg/CardImg.tsx
@@ -5,11 +5,11 @@ import { faHeart, faShoppingBag } from '@fortawesome/free-solid-svg-icons';
 
 type Props = {
   imgSrc: string;
-  width: number
+  viewportWidth: number
 };
 
 export const CardImg: React.FC<Props> = (props: Props) => {
-	const { imgSrc, width } = props;
+	const { imgSrc, viewportWidth } = props;
 	
 	const [like, setLike] = useState(false);
   
@@ -21,7 +21,7 @@ export const CardImg: React.FC<Props> = (props: Props) => {
     <>
       <S.Container>
         <S.ImgWrapper>
-          <S.Img src={imgSrc} width={width}/>
+          <S.Img src={imgSrc} viewportWidth={viewportWidth}/>
         </S.ImgWrapper>
         <S.HeartIcon onClick={toggleLike} icon={faHeart} like={like ? 'red' : 'white'}/>
         <S.ShoppingBagIcon icon={faShoppingBag} />

--- a/client/src/components/CardImg/CardImg.tsx
+++ b/client/src/components/CardImg/CardImg.tsx
@@ -5,10 +5,11 @@ import { faHeart, faShoppingBag } from '@fortawesome/free-solid-svg-icons';
 
 type Props = {
   imgSrc: string;
+  width: number
 };
 
 export const CardImg: React.FC<Props> = (props: Props) => {
-	const { imgSrc } = props;
+	const { imgSrc, width } = props;
 	
 	const [like, setLike] = useState(false);
   
@@ -20,7 +21,7 @@ export const CardImg: React.FC<Props> = (props: Props) => {
     <>
       <S.Container>
         <S.ImgWrapper>
-          <S.Img src={imgSrc} />
+          <S.Img src={imgSrc} width={width}/>
         </S.ImgWrapper>
         <S.HeartIcon onClick={toggleLike} icon={faHeart} like={like ? 'red' : 'white'}/>
         <S.ShoppingBagIcon icon={faShoppingBag} />

--- a/client/src/components/CardImg/CardImgStyle.ts
+++ b/client/src/components/CardImg/CardImgStyle.ts
@@ -13,12 +13,11 @@ export type ImgProps = {
 
 export const Img = styled.img<ImgProps>`
   width: 100%;
-  height: ${props => `${props.width}vw`};
+  height: calc(${props => props.width}vw - 10px);
 `;
 
 export const ImgWrapper = styled.div`
   padding: 5px;
-  width: 100%;
 `;
 
 export type likeProps = {

--- a/client/src/components/CardImg/CardImgStyle.ts
+++ b/client/src/components/CardImg/CardImgStyle.ts
@@ -1,61 +1,63 @@
 import styled from 'styled-components';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 
 export const Container = styled.div`
   position: relative;
-  background-color: #FFFFFFFF;
+  background-color: #ffffffff;
   width: 100%;
-`
+`;
 
-export const Img = styled.img`
-  width:140px;
-  height:140px;
-  /* border-radius:5px; */
-  /* box-shadow: 0.5px 0.5px 3px grey; */
-`
+export type ImgProps = {
+  width: number;
+};
+
+export const Img = styled.img<ImgProps>`
+  width: 100%;
+  height: ${props => `${props.width}vw`};
+`;
 
 export const ImgWrapper = styled.div`
   padding: 5px;
   width: 100%;
-`
+`;
 
 export type likeProps = {
   like: string;
-}
+};
 
 export const HeartIcon = styled(FontAwesomeIcon)<likeProps>`
   color: ${(props) => props.like};
   background-color: #d1d1d1;
   height: 24px;
   border-radius: 50%;
-  padding:5px;
+  padding: 5px;
   position: absolute;
   font-size: 25px;
   top: 10px;
   left: 10px;
-  opacity:0.8;
-`
+  opacity: 0.8;
+`;
 
 export const ShoppingBagIcon = styled(FontAwesomeIcon)`
   color: grey;
-  background-color: #FFFFFFFF;
+  background-color: #ffffffff;
   height: 25px;
   border-radius: 50%;
-  padding:5px;
+  padding: 5px;
   position: absolute;
   font-size: 29px;
   bottom: 10px;
   left: 10px;
   opacity: 0.8;
-`
+`;
 
 export const IQ = styled.div`
   color: black;
-  background-color: #FFFFFFFF;
+  background-color: #ffffffff;
   line-height: 20px;
   border-radius: 10px;
   font-weight: bold;
-  padding:3px;
+  padding: 3px;
   position: absolute;
   font-size: 13px;
   top: 10px;
@@ -64,10 +66,10 @@ export const IQ = styled.div`
   box-sizing: border-box;
   text-align: right;
   vertical-align: middle;
-  opacity:0.8;
+  opacity: 0.8;
   & ::after {
     content: 'IQ';
     color: grey;
-    margin-left:2px;
+    margin-left: 2px;
   }
-`
+`;

--- a/client/src/components/CardImg/CardImgStyle.ts
+++ b/client/src/components/CardImg/CardImgStyle.ts
@@ -8,12 +8,12 @@ export const Container = styled.div`
 `;
 
 export type ImgProps = {
-  width: number;
+  viewportWidth: number;
 };
 
 export const Img = styled.img<ImgProps>`
   width: 100%;
-  height: calc(${props => props.width}vw - 10px);
+  height: calc(${props => props.viewportWidth}vw - 10px);
 `;
 
 export const ImgWrapper = styled.div`

--- a/client/src/components/Carousel/CarouselStyle.ts
+++ b/client/src/components/Carousel/CarouselStyle.ts
@@ -35,7 +35,7 @@ type ImgProps = {
 export const Img = styled.img<ImgProps>`
   display: inline-block;
   width: 100vw;
-  height: 30vh;
+  height: 60vw;
   animation: ${(props) => slide(props.length)} ${(props) => props.length * 3}s
     cubic-bezier(0.785, 0.135, 0.15, 0.86) infinite;
 `;

--- a/client/src/components/FourCardsContainer/FourCardsContainer.tsx
+++ b/client/src/components/FourCardsContainer/FourCardsContainer.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState } from 'react';
 import * as S from './FourCardsContainerStyle';
 import { BigCard } from '../BigCard';
 import { Product } from '../../../../shared';
@@ -18,10 +18,9 @@ const FourCardsContainer: React.FC<FourCardsContainerProps> = ({
 }: FourCardsContainerProps) => {
   const [card, setCard] = useState(products[0]);
 
-  const selectCard = (card:Product) => {
+  const selectCard = (card: Product) => {
     setCard(card);
-  }; 
-
+  };
 
   return (
     <>
@@ -32,12 +31,16 @@ const FourCardsContainer: React.FC<FourCardsContainerProps> = ({
             products.map((product) => (
               <S.Img
                 onClick={() => selectCard(product)}
-                select={card ? (product === card && true) : product === products[0] && true}
+                select={
+                  card
+                    ? product === card && true
+                    : product === products[0] && true
+                }
                 key={product.id}
                 src={product.img}
               />
             ))}
-          {card ? <BigCard {...card}/> : <BigCard {...products[0]}/>}
+          {card ? <BigCard {...card} /> : <BigCard {...products[0]} />}
         </S.Container>
       </MainContainer>
     </>

--- a/client/src/components/FourCardsContainer/FourCardsContainerStyle.ts
+++ b/client/src/components/FourCardsContainer/FourCardsContainerStyle.ts
@@ -1,7 +1,6 @@
 import styled from 'styled-components';
 
 export const Container = styled.div`
-  width: 96vw;
   height: 120vw;
   margin: 2vw;
 `;

--- a/client/src/components/HorizontalBar/HorizontalBar.tsx
+++ b/client/src/components/HorizontalBar/HorizontalBar.tsx
@@ -5,9 +5,10 @@ type Props = {
   start?: any;
   center?: any;
   end?: any;
+  displayNextProducts?: () => void;
 };
 
-const HorizontalBar: React.FC<Props> = ({ start, center, end }: Props) => {
+const HorizontalBar: React.FC<Props> = ({ start, center, end, displayNextProducts }: Props) => {
   return (
     <S.Container
       isStart={start ? '1fr' : ''}
@@ -15,7 +16,7 @@ const HorizontalBar: React.FC<Props> = ({ start, center, end }: Props) => {
       isEnd={end ? '1fr' : ''}
     >
       {start !== undefined && <S.Start>{start}</S.Start>}
-      {center !== undefined && <S.Center>{center}</S.Center>}
+      {center !== undefined && <S.Center onClick={displayNextProducts}>{center}</S.Center>}
       {end !== undefined && <S.End>{end}</S.End>}
     </S.Container>
   );

--- a/client/src/components/HorizontalSlider/HorizontalSlider.tsx
+++ b/client/src/components/HorizontalSlider/HorizontalSlider.tsx
@@ -27,7 +27,7 @@ const HorizontalSlider: React.FC<HorizontalSliderProps> = ({
             <Card
               key={product.id}
               product={product}
-              width={HORIZONTAL_CARD_VIEWPORT_WIDTH}
+              viewportWidth={HORIZONTAL_CARD_VIEWPORT_WIDTH}
             />
           ))}
       </S.Container>

--- a/client/src/components/HorizontalSlider/HorizontalSlider.tsx
+++ b/client/src/components/HorizontalSlider/HorizontalSlider.tsx
@@ -11,7 +11,7 @@ type HorizontalSliderProps = {
   products: Product[];
 };
 
-const HORIZONTAL_CARD_WIDTH = 40;
+const HORIZONTAL_CARD_VIEWPORT_WIDTH = 40;
 
 const HorizontalSlider: React.FC<HorizontalSliderProps> = ({
   start,
@@ -27,7 +27,7 @@ const HorizontalSlider: React.FC<HorizontalSliderProps> = ({
             <Card
               key={product.id}
               product={product}
-              width={HORIZONTAL_CARD_WIDTH}
+              width={HORIZONTAL_CARD_VIEWPORT_WIDTH}
             />
           ))}
       </S.Container>

--- a/client/src/components/HorizontalSlider/HorizontalSlider.tsx
+++ b/client/src/components/HorizontalSlider/HorizontalSlider.tsx
@@ -11,6 +11,8 @@ type HorizontalSliderProps = {
   products: Product[];
 };
 
+const HORIZONTAL_CARD_WIDTH = 40;
+
 const HorizontalSlider: React.FC<HorizontalSliderProps> = ({
   start,
   end,
@@ -21,7 +23,13 @@ const HorizontalSlider: React.FC<HorizontalSliderProps> = ({
       {(start || end) && <HorizontalBar start={start} end={end} />}
       <S.Container>
         {products &&
-          products.map((product) => <Card key={product.id} {...product} />)}
+          products.map((product) => (
+            <Card
+              key={product.id}
+              product={product}
+              width={HORIZONTAL_CARD_WIDTH}
+            />
+          ))}
       </S.Container>
     </MainContainer>
   );

--- a/client/src/components/SixCardsContainer/SixCardsContainer.test.tsx
+++ b/client/src/components/SixCardsContainer/SixCardsContainer.test.tsx
@@ -1,0 +1,19 @@
+import '@testing-library/jest-dom/extend-expect';
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react';
+
+import {SixCardsContainer} from './';
+
+describe('SixCardsContainer comopoent', () => {
+  it('matches snapshot', () => {
+    const { container } = render(<SixCardsContainer />);
+    expect(container).toMatchSnapshot();
+  });
+
+  it('shows the elemnts correctly', () => {
+    const utils = render(<SixCardsContainer />);
+    // utils.getByText('+');
+
+  });
+});
+

--- a/client/src/components/SixCardsContainer/SixCardsContainer.tsx
+++ b/client/src/components/SixCardsContainer/SixCardsContainer.tsx
@@ -35,8 +35,7 @@ const SixCardsContainer: React.FC<SixCardsContainerProps> = ({
         <S.Container>
           {selectedProducts &&
             selectedProducts.map((product) => (
-              <S.CardWrapper><Card
-                key={product.id}
+              <S.CardWrapper key={product.id}><Card
                 product={product}
                 width={SIXCARDSCONTAINER_CARD_VIEWPORT_WIDTH}
               /></S.CardWrapper>

--- a/client/src/components/SixCardsContainer/SixCardsContainer.tsx
+++ b/client/src/components/SixCardsContainer/SixCardsContainer.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import * as S from './SixCardsContainerStyle';
+import { MainContainer } from '../MainContainer';
+import { HorizontalBar } from '../HorizontalBar';
+import { Card } from '../Card';
+
+type SixCardsContainerProps = {
+  start?: any;
+  end?: any;
+  products: Product[];
+};
+
+const SixCardsContainer: React.FC<SixCardsContainerProps> = ({
+  start,
+  end,
+  products,
+}: SixCardsContainerProps) => {
+  return (
+    <>
+      <MainContainer>
+        {(start || end) && <HorizontalBar start={start} end={end} />}
+        <S.Container>
+          {products &&
+            products.map((product) => <Card key={product.id} {...product} />)}
+        </S.Container>
+      </MainContainer>
+    </>
+  );
+};
+
+export default SixCardsContainer;

--- a/client/src/components/SixCardsContainer/SixCardsContainer.tsx
+++ b/client/src/components/SixCardsContainer/SixCardsContainer.tsx
@@ -11,21 +11,24 @@ type SixCardsContainerProps = {
   products: Product[];
 };
 
-const SIXCARDSCONTAINER_CARD_VIEWPORT_WIDTH = 32;
+const SIX_CARDS_CONTAINER_CARD_VIEWPORT_WIDTH = 32;
 
 const SixCardsContainer: React.FC<SixCardsContainerProps> = ({
   start,
   end,
   products,
 }: SixCardsContainerProps) => {
-  const [firstProduct, setFirstProduct] = useState(0);
-  const selectedProducts = products.slice(firstProduct, firstProduct + 6);
-  const pageCount = (firstProduct / 6) + 1;
+  const [pageIndex, setPageIndex] = useState(1);
+  const PRODUCT_PER_PAGE = 6;
+  const selectedProducts = products.slice(
+    (pageIndex - 1) * PRODUCT_PER_PAGE,
+    pageIndex * PRODUCT_PER_PAGE
+  );
 
   const displayNextProducts = () => {
-    firstProduct === 18
-      ? setFirstProduct(0)
-      : setFirstProduct(firstProduct + 6);
+    pageIndex === 4
+      ? setPageIndex(1)
+      : setPageIndex(pageIndex + 1);
   };
 
   return (
@@ -35,15 +38,17 @@ const SixCardsContainer: React.FC<SixCardsContainerProps> = ({
         <S.Container>
           {selectedProducts &&
             selectedProducts.map((product) => (
-              <S.CardWrapper key={product.id}><Card
-                product={product}
-                width={SIXCARDSCONTAINER_CARD_VIEWPORT_WIDTH}
-              /></S.CardWrapper>
+              <S.CardWrapper key={product.id}>
+                <Card
+                  product={product}
+                  viewportWidth={SIX_CARDS_CONTAINER_CARD_VIEWPORT_WIDTH}
+                />
+              </S.CardWrapper>
             ))}
         </S.Container>
         <HorizontalBar
           displayNextProducts={displayNextProducts}
-            center={`↻ 지금 뭐 먹지? 다른 상품 보기 ${pageCount}/4`}
+          center={`↻ 지금 뭐 먹지? 다른 상품 보기 ${pageIndex}/4`}
         />
       </MainContainer>
     </>

--- a/client/src/components/SixCardsContainer/SixCardsContainer.tsx
+++ b/client/src/components/SixCardsContainer/SixCardsContainer.tsx
@@ -20,6 +20,7 @@ const SixCardsContainer: React.FC<SixCardsContainerProps> = ({
 }: SixCardsContainerProps) => {
   const [firstProduct, setFirstProduct] = useState(0);
   const selectedProducts = products.slice(firstProduct, firstProduct + 6);
+  const pageCount = (firstProduct / 6) + 1;
 
   const displayNextProducts = () => {
     firstProduct === 18
@@ -43,7 +44,7 @@ const SixCardsContainer: React.FC<SixCardsContainerProps> = ({
         </S.Container>
         <HorizontalBar
           displayNextProducts={displayNextProducts}
-          center="↻ 지금 뭐 먹지? 다른 상품 보기"
+            center={`↻ 지금 뭐 먹지? 다른 상품 보기 ${pageCount}/4`}
         />
       </MainContainer>
     </>

--- a/client/src/components/SixCardsContainer/SixCardsContainer.tsx
+++ b/client/src/components/SixCardsContainer/SixCardsContainer.tsx
@@ -35,11 +35,11 @@ const SixCardsContainer: React.FC<SixCardsContainerProps> = ({
         <S.Container>
           {selectedProducts &&
             selectedProducts.map((product) => (
-              <Card
+              <S.CardWrapper><Card
                 key={product.id}
                 product={product}
                 width={SIXCARDSCONTAINER_CARD_VIEWPORT_WIDTH}
-              />
+              /></S.CardWrapper>
             ))}
         </S.Container>
         <HorizontalBar

--- a/client/src/components/SixCardsContainer/SixCardsContainer.tsx
+++ b/client/src/components/SixCardsContainer/SixCardsContainer.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import * as S from './SixCardsContainerStyle';
 import { MainContainer } from '../MainContainer';
 import { HorizontalBar } from '../HorizontalBar';
+import { Product } from '../../../../shared';
 import { Card } from '../Card';
 
 type SixCardsContainerProps = {
@@ -10,7 +11,7 @@ type SixCardsContainerProps = {
   products: Product[];
 };
 
-const SIXCARDCONTAINER_CARD_WIDTH = 200;
+const SIXCARDSCONTAINER_CARD_VIEWPORT_WIDTH = 31;
 
 const SixCardsContainer: React.FC<SixCardsContainerProps> = ({
   start,
@@ -22,10 +23,14 @@ const SixCardsContainer: React.FC<SixCardsContainerProps> = ({
       <MainContainer>
         {(start || end) && <HorizontalBar start={start} end={end} />}
         <S.Container>
-          {/* {products &&
+          {products &&
             products.map((product) => (
-              <Card key={product.id} {...product} width={100} />
-            ))} */}
+              <Card
+                key={product.id}
+                product={product}
+                width={SIXCARDSCONTAINER_CARD_VIEWPORT_WIDTH}
+              />
+            ))}
         </S.Container>
       </MainContainer>
     </>

--- a/client/src/components/SixCardsContainer/SixCardsContainer.tsx
+++ b/client/src/components/SixCardsContainer/SixCardsContainer.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import * as S from './SixCardsContainerStyle';
 import { MainContainer } from '../MainContainer';
 import { HorizontalBar } from '../HorizontalBar';
@@ -11,20 +11,29 @@ type SixCardsContainerProps = {
   products: Product[];
 };
 
-const SIXCARDSCONTAINER_CARD_VIEWPORT_WIDTH = 31;
+const SIXCARDSCONTAINER_CARD_VIEWPORT_WIDTH = 32;
 
 const SixCardsContainer: React.FC<SixCardsContainerProps> = ({
   start,
   end,
   products,
 }: SixCardsContainerProps) => {
+  const [firstProduct, setFirstProduct] = useState(0);
+  const selectedProducts = products.slice(firstProduct, firstProduct + 6);
+
+  const displayNextProducts = () => {
+    firstProduct === 18
+      ? setFirstProduct(0)
+      : setFirstProduct(firstProduct + 6);
+  };
+
   return (
     <>
       <MainContainer>
         {(start || end) && <HorizontalBar start={start} end={end} />}
         <S.Container>
-          {products &&
-            products.map((product) => (
+          {selectedProducts &&
+            selectedProducts.map((product) => (
               <Card
                 key={product.id}
                 product={product}
@@ -32,6 +41,10 @@ const SixCardsContainer: React.FC<SixCardsContainerProps> = ({
               />
             ))}
         </S.Container>
+        <HorizontalBar
+          displayNextProducts={displayNextProducts}
+          center="↻ 지금 뭐 먹지? 다른 상품 보기"
+        />
       </MainContainer>
     </>
   );

--- a/client/src/components/SixCardsContainer/SixCardsContainer.tsx
+++ b/client/src/components/SixCardsContainer/SixCardsContainer.tsx
@@ -10,6 +10,8 @@ type SixCardsContainerProps = {
   products: Product[];
 };
 
+const SIXCARDCONTAINER_CARD_WIDTH = 200;
+
 const SixCardsContainer: React.FC<SixCardsContainerProps> = ({
   start,
   end,
@@ -20,8 +22,10 @@ const SixCardsContainer: React.FC<SixCardsContainerProps> = ({
       <MainContainer>
         {(start || end) && <HorizontalBar start={start} end={end} />}
         <S.Container>
-          {products &&
-            products.map((product) => <Card key={product.id} {...product} />)}
+          {/* {products &&
+            products.map((product) => (
+              <Card key={product.id} {...product} width={100} />
+            ))} */}
         </S.Container>
       </MainContainer>
     </>

--- a/client/src/components/SixCardsContainer/SixCardsContainerStyle.ts
+++ b/client/src/components/SixCardsContainer/SixCardsContainerStyle.ts
@@ -1,4 +1,6 @@
 import styled from 'styled-components';
 
-export const Container = styled.div``
+export const Container = styled.div`
+  margin: 0 2vw 2vw 2vw;
+`
 

--- a/client/src/components/SixCardsContainer/SixCardsContainerStyle.ts
+++ b/client/src/components/SixCardsContainer/SixCardsContainerStyle.ts
@@ -1,0 +1,4 @@
+import styled from 'styled-components';
+
+export const Container = styled.div``
+

--- a/client/src/components/SixCardsContainer/SixCardsContainerStyle.ts
+++ b/client/src/components/SixCardsContainer/SixCardsContainerStyle.ts
@@ -2,5 +2,10 @@ import styled from 'styled-components';
 
 export const Container = styled.div`
   margin: 0 2vw 2vw 2vw;
+  /* height: 330px; */
+`
+export const CardWrapper = styled.div`
+  display:inline-block;
+  height: 48vw;
 `
 

--- a/client/src/components/SixCardsContainer/index.ts
+++ b/client/src/components/SixCardsContainer/index.ts
@@ -1,0 +1,1 @@
+export {default as SixCardsContainer} from './SixCardsContainer'

--- a/client/src/pages/index.tsx
+++ b/client/src/pages/index.tsx
@@ -12,6 +12,7 @@ import { HorizontalSlider } from '../components/HorizontalSlider';
 import { FourCardsContainer } from '../components/FourCardsContainer';
 import { useProduct } from '../hooks/useProduct';
 import { CartButton } from '../components/CartButton';
+import { SixCardsContainer } from '../components/SixCardsContainer';
 
 const IndexPage = ({
   bannerImages,
@@ -35,6 +36,7 @@ const IndexPage = ({
               end={'더보기 〉'}
               products={products.slice(40, 44)}
             />
+            <SixCardsContainer start={'지금 뭐 먹지?'} products={products.slice(44, 68)}/>
             <HorizontalSlider
               start={'특별 모음전'}
               end={'더보기 〉'}


### PR DESCRIPTION
### 요약
- 6개의 카드를 담는 컨테이너 컴포넌트 생성
  - 하단의 '지금 뭐 먹지?' 클릭시 카드 구성 변경
  - 낼 오전에 만나긴 어려울듯..

### 개발 결과물
<kbd>
<img width="300" src="https://user-images.githubusercontent.com/34447105/91217502-93217780-e752-11ea-9704-07eca780d91e.gif">
</kbd>

### 관련 이슈
#27