### PR TITLE
Feat/27/두 줄로 정렬되는 카드 컨테이너 생성

### DIFF
--- a/client/src/components/TenCardsContainer/TenCardsContainer.test.tsx
+++ b/client/src/components/TenCardsContainer/TenCardsContainer.test.tsx
@@ -1,0 +1,19 @@
+import '@testing-library/jest-dom/extend-expect';
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react';
+
+import {TenCardsContainer} from './';
+
+describe('TenCardsContainer comopoent', () => {
+  it('matches snapshot', () => {
+    const { container } = render(<TenCardsContainer />);
+    expect(container).toMatchSnapshot();
+  });
+
+  it('shows the elemnts correctly', () => {
+    const utils = render(<TenCardsContainer />);
+    // utils.getByText('+');
+
+  });
+});
+

--- a/client/src/components/TenCardsContainer/TenCardsContainer.tsx
+++ b/client/src/components/TenCardsContainer/TenCardsContainer.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import * as S from './TenCardsContainerStyle';
+import { MainContainer } from '../MainContainer';
+import { HorizontalBar } from '../HorizontalBar';
+import { Product } from '../../../../shared';
+import { Card } from '../Card';
+
+type TenCardsContainerProps = {
+  start?: any;
+  end?: any;
+  products: Product[];
+};
+
+const TEN_CARDS_CONTAINER_CARD_VIEWPORT_WIDTH = 48;
+
+const TenCardsContainer: React.FC<TenCardsContainerProps> = ({
+  start,
+  end,
+  products,
+}: TenCardsContainerProps) => {
+  return (
+    <>
+      <MainContainer>
+        {(start || end) && <HorizontalBar start={start} end={end} />}
+        <S.Container>
+          {products &&
+            products.map((product) => (
+              <S.CardWrapper key={product.id}>
+                <Card
+                  product={product}
+                  viewportWidth={TEN_CARDS_CONTAINER_CARD_VIEWPORT_WIDTH}
+                />
+              </S.CardWrapper>
+            ))}
+        </S.Container>
+      </MainContainer>
+    </>
+  );
+};
+
+export default TenCardsContainer;

--- a/client/src/components/TenCardsContainer/TenCardsContainerStyle.ts
+++ b/client/src/components/TenCardsContainer/TenCardsContainerStyle.ts
@@ -1,0 +1,9 @@
+import styled from 'styled-components';
+
+export const Container = styled.div`
+  margin: 0 2vw 2vw 2vw;
+`
+export const CardWrapper = styled.div`
+  display:inline-block;
+  height: 48vw;
+`

--- a/client/src/components/TenCardsContainer/TenCardsContainerStyle.ts
+++ b/client/src/components/TenCardsContainer/TenCardsContainerStyle.ts
@@ -5,5 +5,4 @@ export const Container = styled.div`
 `
 export const CardWrapper = styled.div`
   display:inline-block;
-  height: 48vw;
 `

--- a/client/src/components/TenCardsContainer/index.ts
+++ b/client/src/components/TenCardsContainer/index.ts
@@ -1,0 +1,1 @@
+export {default as TenCardsContainer} from './TenCardsContainer'

--- a/client/src/pages/index.tsx
+++ b/client/src/pages/index.tsx
@@ -13,6 +13,7 @@ import { FourCardsContainer } from '../components/FourCardsContainer';
 import { useProduct } from '../hooks/useProduct';
 import { CartButton } from '../components/CartButton';
 import { SixCardsContainer } from '../components/SixCardsContainer';
+import { TenCardsContainer } from '../components/TenCardsContainer';
 
 const IndexPage = ({
   bannerImages,
@@ -49,6 +50,11 @@ const IndexPage = ({
             <HorizontalSlider
               start={'날이면 날마다 오는 세일 ㅇㅇ'}
               products={products.slice(30, 40)}
+            />
+            <TenCardsContainer
+              start={'카테고리 이름'}
+              end={'더보기 〉'}
+              products={products.slice(68, 78)}
             />
           </>
         )}


### PR DESCRIPTION
### 요약
- 메인 및 기타 페이지에 사용할 '두 줄 정렬 카드 컨테이너' 생성
- 입력 Product 데이터의 개수 만큼 카드가 화면에 출력됨

### 개발 결과물
<kbd>
<img width="300" src="https://user-images.githubusercontent.com/34447105/91267937-5cc61580-e7af-11ea-9560-4c12792224de.png">
</kbd>

### 관련 이슈
#27 