### PR TITLE
Feat/99/product detail

### DIFF
--- a/client/src/api/product.ts
+++ b/client/src/api/product.ts
@@ -21,6 +21,12 @@ const getAllProduct = async () => {
   return data;
 };
 
+const getOne = async (id: number) => {
+  const { data } = await bmart.get<Product>(`/product/one/${id}`);
+
+  return data;
+};
+
 const getByKeyword = async (keyword: string) => {
   const { data } = await bmart.get<Product[]>(`/product/keyword/${keyword}`);
 
@@ -32,4 +38,5 @@ export default {
   getAllProduct,
   getByCategory,
   getByKeyword,
+  getOne,
 };

--- a/client/src/components/BigCard/BigCard.tsx
+++ b/client/src/components/BigCard/BigCard.tsx
@@ -3,15 +3,25 @@ import * as S from './BigCardStyle';
 import { BigCardImg } from '../BigCardImg';
 import { BigCardContent } from '../BigCardContent';
 import { Product } from '../../../../shared';
+import Link from 'next/link';
 
-const BigCard: React.FC<Product> = (product: Product) => {
-  const { img } = product;
+type ProductProps = {
+  product: Product;
+};
+
+const BigCard: React.FC<ProductProps> = ({ product }: ProductProps) => {
+  if (!product) {
+    return null;
+  }
+  const { img, id } = product;
 
   return (
-    <S.Container>
-      <BigCardImg imgSrc={img} />
-      <BigCardContent {...product} />
-    </S.Container>
+    <Link key={id} href="/product/[id]" as={`/product/${id}`}>
+      <S.Container>
+        <BigCardImg imgSrc={img} />
+        <BigCardContent {...product} />
+      </S.Container>
+    </Link>
   );
 };
 

--- a/client/src/components/BigCard/BigCardStyle.ts
+++ b/client/src/components/BigCard/BigCardStyle.ts
@@ -2,5 +2,11 @@ import styled from 'styled-components';
 
 export const Container = styled.div`
   width: 100%;
-`
 
+  /* &:active {
+    img {
+      transition: all 200ms ease;
+      transform: scale(1.05);
+    }
+  } */
+`;

--- a/client/src/components/BigCardImg/BigCardImg.tsx
+++ b/client/src/components/BigCardImg/BigCardImg.tsx
@@ -7,13 +7,15 @@ type Props = {
 };
 
 export const BigCardImg: React.FC<Props> = (props: Props) => {
-	const { imgSrc } = props;
-	
-	const [like, setLike] = useState(false);
-  
-	const toggleLike = () => {
-		setLike(!like);
-	};
+  const { imgSrc } = props;
+
+  const [like, setLike] = useState(false);
+
+  const toggleLike = (event: React.MouseEvent<SVGSVGElement, MouseEvent>) => {
+    event.stopPropagation();
+
+    setLike(!like);
+  };
 
   return (
     <>
@@ -21,7 +23,11 @@ export const BigCardImg: React.FC<Props> = (props: Props) => {
         <S.ImgWrapper>
           <S.Img src={imgSrc} />
         </S.ImgWrapper>
-        <S.HeartIcon onClick={toggleLike} icon={faHeart} like={like ? 'red' : 'white'}/>
+        <S.HeartIcon
+          onClick={toggleLike}
+          icon={faHeart}
+          like={like ? 'red' : 'white'}
+        />
       </S.Container>
     </>
   );

--- a/client/src/components/BigCardImg/BigCardImgStyle.ts
+++ b/client/src/components/BigCardImg/BigCardImgStyle.ts
@@ -1,17 +1,17 @@
 import styled from 'styled-components';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 
 export const Container = styled.div`
   position: relative;
-  background-color: #FFFFFFFF;
+  background-color: #ffffffff;
   width: 100%;
-`
+`;
 
 export const Img = styled.img`
-  width:100%;
+  width: 100%;
   position: absolute;
   top: -10vw;
-`
+`;
 
 export const ImgWrapper = styled.div`
   width: 94vw;
@@ -19,21 +19,27 @@ export const ImgWrapper = styled.div`
   margin: auto 1vw;
   position: relative;
   overflow: hidden;
-`
+`;
 
 export type likeProps = {
   like: string;
-}
+};
 
 export const HeartIcon = styled(FontAwesomeIcon)<likeProps>`
   color: ${(props) => props.like};
   background-color: #d1d1d1;
   height: 40px;
   border-radius: 50%;
-  padding:10px;
+  padding: 10px;
   position: absolute;
   font-size: 40px;
   bottom: 10px;
   right: 10px;
-  opacity:0.6;
-`
+  opacity: 0.6;
+
+  transition: all 100ms ease;
+  &:active {
+    transform: scale(1.15);
+    opacity: 1;
+  }
+`;

--- a/client/src/components/BoxCategory/BoxCategoryStyle.ts
+++ b/client/src/components/BoxCategory/BoxCategoryStyle.ts
@@ -1,5 +1,5 @@
 import styled from 'styled-components';
-import { GRAY_001 } from '../../styles/GlobalStyle';
+import { GRAY_001, GRAY_003 } from '../../styles/GlobalStyle';
 
 export const Container = styled.div`
   display: flex;
@@ -8,11 +8,16 @@ export const Container = styled.div`
 
 export const Item = styled.div`
   display: flex;
-  /* justify-content: center; */
   padding: 0 0 0 20px;
   align-items: center;
   width: 50%;
   height: 50px;
   font-weight: 200;
   border: 0.5px solid ${GRAY_001};
+
+  transition: all 100ms ease;
+  &:active {
+    background: ${GRAY_003};
+    transform: scale(0.98);
+  }
 `;

--- a/client/src/components/Card/Card.tsx
+++ b/client/src/components/Card/Card.tsx
@@ -3,15 +3,25 @@ import * as S from './CardStyle';
 import { CardImg } from './../CardImg';
 import { CardContent } from './../CardContent';
 import { Product } from '../../../../shared';
+import Link from 'next/link';
 
-const Card: React.FC<Product> = (product: Product) => {
-  const { img } = product;
+type ProductProps = {
+  product: Product;
+};
+
+const Card: React.FC<ProductProps> = ({ product }: ProductProps) => {
+  if (!product) {
+    return null;
+  }
+  const { img, id } = product;
 
   return (
-    <S.Container>
-      <CardImg imgSrc={img} />
-      <CardContent {...product} />
-    </S.Container>
+    <Link href="/product/[id]" as={`/product/${id}`}>
+      <S.Container>
+        <CardImg imgSrc={img} />
+        <CardContent {...product} />
+      </S.Container>
+    </Link>
   );
 };
 

--- a/client/src/components/Card/CardStyle.ts
+++ b/client/src/components/Card/CardStyle.ts
@@ -4,6 +4,12 @@ export const Container = styled.div`
   display: inline-block;
   width: 150px;
   /* height: 150px; */
-  vertical-align:top;
-`
+  vertical-align: top;
 
+  /* &:active {
+    img {
+      transition: all 200ms ease;
+      transform: scale(1.05);
+    }
+  } */
+`;

--- a/client/src/components/CardImg/CardImg.tsx
+++ b/client/src/components/CardImg/CardImg.tsx
@@ -8,13 +8,15 @@ type Props = {
 };
 
 export const CardImg: React.FC<Props> = (props: Props) => {
-	const { imgSrc } = props;
-	
-	const [like, setLike] = useState(false);
-  
-	const toggleLike = () => {
-		setLike(!like);
-	};
+  const { imgSrc } = props;
+
+  const [like, setLike] = useState(false);
+
+  const toggleLike = (event: React.MouseEvent<SVGSVGElement, MouseEvent>) => {
+    event.stopPropagation();
+
+    setLike(!like);
+  };
 
   return (
     <>
@@ -22,7 +24,11 @@ export const CardImg: React.FC<Props> = (props: Props) => {
         <S.ImgWrapper>
           <S.Img src={imgSrc} />
         </S.ImgWrapper>
-        <S.HeartIcon onClick={toggleLike} icon={faHeart} like={like ? 'red' : 'white'}/>
+        <S.HeartIcon
+          onClick={toggleLike}
+          icon={faHeart}
+          like={like ? 'red' : 'white'}
+        />
         <S.ShoppingBagIcon icon={faShoppingBag} />
       </S.Container>
     </>

--- a/client/src/components/CardImg/CardImgStyle.ts
+++ b/client/src/components/CardImg/CardImgStyle.ts
@@ -1,61 +1,67 @@
 import styled from 'styled-components';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 
 export const Container = styled.div`
   position: relative;
-  background-color: #FFFFFFFF;
+  background-color: #ffffffff;
   width: 100%;
-`
+`;
 
 export const Img = styled.img`
-  width:140px;
-  height:140px;
+  width: 140px;
+  height: 140px;
   /* border-radius:5px; */
   /* box-shadow: 0.5px 0.5px 3px grey; */
-`
+`;
 
 export const ImgWrapper = styled.div`
   padding: 5px;
   width: 100%;
-`
+`;
 
 export type likeProps = {
   like: string;
-}
+};
 
 export const HeartIcon = styled(FontAwesomeIcon)<likeProps>`
   color: ${(props) => props.like};
   background-color: #d1d1d1;
   height: 24px;
   border-radius: 50%;
-  padding:5px;
+  padding: 5px;
   position: absolute;
   font-size: 25px;
   top: 10px;
   left: 10px;
-  opacity:0.8;
-`
+  opacity: 0.8;
+
+  transition: all 100ms ease;
+  &:active {
+    transform: scale(1.15);
+    opacity: 1;
+  }
+`;
 
 export const ShoppingBagIcon = styled(FontAwesomeIcon)`
   color: grey;
-  background-color: #FFFFFFFF;
+  background-color: #ffffffff;
   height: 25px;
   border-radius: 50%;
-  padding:5px;
+  padding: 5px;
   position: absolute;
   font-size: 29px;
   bottom: 10px;
   left: 10px;
   opacity: 0.8;
-`
+`;
 
 export const IQ = styled.div`
   color: black;
-  background-color: #FFFFFFFF;
+  background-color: #ffffffff;
   line-height: 20px;
   border-radius: 10px;
   font-weight: bold;
-  padding:3px;
+  padding: 3px;
   position: absolute;
   font-size: 13px;
   top: 10px;
@@ -64,10 +70,10 @@ export const IQ = styled.div`
   box-sizing: border-box;
   text-align: right;
   vertical-align: middle;
-  opacity:0.8;
+  opacity: 0.8;
   & ::after {
     content: 'IQ';
     color: grey;
-    margin-left:2px;
+    margin-left: 2px;
   }
-`
+`;

--- a/client/src/components/CategoryContainer/CategoryContainerStyle.ts
+++ b/client/src/components/CategoryContainer/CategoryContainerStyle.ts
@@ -14,4 +14,9 @@ export const Category = styled.img`
   display: inline-block;
   width: 20%;
   height: 50%;
+
+  transition: all 100ms ease;
+  &:active {
+    transform: scale(1.1);
+  }
 `;

--- a/client/src/components/FourCardsContainer/FourCardsContainer.tsx
+++ b/client/src/components/FourCardsContainer/FourCardsContainer.tsx
@@ -18,10 +18,9 @@ const FourCardsContainer: React.FC<FourCardsContainerProps> = ({
 }: FourCardsContainerProps) => {
   const [card, setCard] = useState(products[0]);
 
-  const selectCard = (card:Product) => {
+  const selectCard = (card: Product) => {
     setCard(card);
-  }; 
-
+  };
 
   return (
     <>
@@ -32,12 +31,16 @@ const FourCardsContainer: React.FC<FourCardsContainerProps> = ({
             products.map((product) => (
               <S.Img
                 onClick={() => selectCard(product)}
-                select={card ? (product === card && true) : product === products[0] && true}
+                select={
+                  card
+                    ? product === card && true
+                    : product === products[0] && true
+                }
                 key={product.id}
                 src={product.img}
               />
             ))}
-          {card ? <BigCard {...card}/> : <BigCard {...products[0]}/>}
+          <BigCard product={card || products[0]} />
         </S.Container>
       </MainContainer>
     </>

--- a/client/src/components/Header/Header.tsx
+++ b/client/src/components/Header/Header.tsx
@@ -34,14 +34,18 @@ const Header: React.FC<Props> = ({ title }: Props) => {
           )
         }
         center={
-          <Link href="/">
-            <S.Image height="30px" src={Images.MAIN_LOGO} />
-          </Link>
+          title ? (
+            <S.Title>{title}</S.Title>
+          ) : (
+            <Link href="/">
+              <S.Image height="30px" src={Images.MAIN_LOGO} />
+            </Link>
+          )
         }
         end={<IconButton icon={faBars} onClickHandler={toggleOpen} />}
       />
       {inputVisiblePath.has(pathname) && <SearchBar />}
-      {title && <HorizontalBar center={<S.Title>{title}</S.Title>} />}
+      {/* {title && <HorizontalBar center={<S.Title>{title}</S.Title>} />} */}
     </S.Container>
   );
 };

--- a/client/src/components/HorizontalSlider/HorizontalSlider.tsx
+++ b/client/src/components/HorizontalSlider/HorizontalSlider.tsx
@@ -21,7 +21,9 @@ const HorizontalSlider: React.FC<HorizontalSliderProps> = ({
       {(start || end) && <HorizontalBar start={start} end={end} />}
       <S.Container>
         {products &&
-          products.map((product) => <Card key={product.id} {...product} />)}
+          products.map((product) => (
+            <Card key={product.id} product={product} />
+          ))}
       </S.Container>
     </MainContainer>
   );

--- a/client/src/components/IconButton/IconButtonStyle.ts
+++ b/client/src/components/IconButton/IconButtonStyle.ts
@@ -2,8 +2,9 @@ import styled from 'styled-components';
 
 export const Container = styled.div`
   font-size: large;
-  transition: 0.1s;
+
+  transition: all 100ms ease;
   &:active {
-    font-size: x-large;
+    transform: scale(1.1);
   }
 `;

--- a/client/src/components/SideMenu/SideMenu.tsx
+++ b/client/src/components/SideMenu/SideMenu.tsx
@@ -3,7 +3,6 @@ import * as S from './SideMenuStyle';
 import { useUser } from '../../hooks/useUser';
 import { Images } from '../../images';
 import { HorizontalBar } from '../HorizontalBar';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faArrowLeft } from '@fortawesome/free-solid-svg-icons';
 import { MainContainer } from '../MainContainer';
 import { useRouter } from 'next/router';

--- a/client/src/pages/index.tsx
+++ b/client/src/pages/index.tsx
@@ -1,13 +1,9 @@
 import React from 'react';
-import Link from 'next/link';
 import API from '../api';
 import { InferGetStaticPropsType } from 'next';
 import { Carousel } from '../components/Carousel';
-// import { Header } from '../components/Header';
 import { Header } from '../components/Header';
-import { HorizontalBar } from '../components/HorizontalBar';
 import { CategoryContainer } from '../components/CategoryContainer';
-import { MainContainer } from '../components/MainContainer';
 import { HorizontalSlider } from '../components/HorizontalSlider';
 import { FourCardsContainer } from '../components/FourCardsContainer';
 import { useProduct } from '../hooks/useProduct';

--- a/client/src/pages/product/[id].tsx
+++ b/client/src/pages/product/[id].tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import API from '../../api';
+import { InferGetStaticPropsType, GetStaticPropsContext } from 'next';
+import { Header } from '../../components/Header';
+import { BigCard } from '../../components/BigCard';
+
+const ProductDetailPage = ({
+  productInfo,
+}: InferGetStaticPropsType<typeof getStaticProps>) => {
+  return (
+    <>
+      <Header title={productInfo.category2} />
+      <BigCard product={productInfo} />
+    </>
+  );
+};
+
+export const getStaticPaths = async () => {
+  return {
+    paths: [],
+    fallback: true,
+  };
+};
+
+export const getStaticProps = async ({ params }: GetStaticPropsContext) => {
+  const productInfo = await API.Product.getOne(Number(params!.id));
+
+  return {
+    props: { productInfo },
+  };
+};
+
+export default ProductDetailPage;

--- a/client/src/pages/product/[id].tsx
+++ b/client/src/pages/product/[id].tsx
@@ -7,6 +7,10 @@ import { BigCard } from '../../components/BigCard';
 const ProductDetailPage = ({
   productInfo,
 }: InferGetStaticPropsType<typeof getStaticProps>) => {
+  if (!productInfo) {
+    return null;
+  }
+
   return (
     <>
       <Header title={productInfo.category2} />

--- a/server/src/repository/product-repository.ts
+++ b/server/src/repository/product-repository.ts
@@ -46,7 +46,7 @@ export class ProductRepo {
     return await insertQueryExecuter(productCreateQuery);
   }
 
-  static async findOne(id: number): Promise<ProductType[]> {
+  static async findOne(id: number): Promise<ProductType> {
     const findOneProductQuery = `
       select product.id id, product.name name, product.discount discount, 
             product.img img, product.base_price base_price, product.price price, product.stock stock, 
@@ -60,7 +60,7 @@ export class ProductRepo {
         where product.id = ${id};
     `;
 
-    const product: ProductType[] = await selectQueryExecuter<ProductType>(
+    const [product, _]: ProductType[] = await selectQueryExecuter<ProductType>(
       findOneProductQuery
     );
     return product;

--- a/server/src/routes/product-routes.ts
+++ b/server/src/routes/product-routes.ts
@@ -15,9 +15,9 @@ const router = Router();
 // all product
 router.get('/', getAllProduct);
 
-router.get('/category', getProductsByCategory);
+router.get('/one/:id', getProductById);
 
-router.get('/:id', getProductById);
+router.get('/category', getProductsByCategory);
 
 router.get('/keyword/:keyword', getProductsByKeyword);
 

--- a/server/src/service/product-service.ts
+++ b/server/src/service/product-service.ts
@@ -30,17 +30,12 @@ export const getProductsByKeyword = async (req: Request, res: Response) => {
 };
 
 export const getProductById = async (req: Request, res: Response) => {
-  const id = Number(req.params.category2_id);
+  const id = Number(req.params.id);
   if (typeof id !== 'number' || id <= 0) {
     throw new InvalidParamsError('id');
   }
 
   const product = await ProductRepo.findOne(id);
-
-  if (product.length === 0) {
-    res.json(`id [${id}]는 존재하지 않는 상품입니다.`);
-    return;
-  }
 
   res.json(product);
 };

--- a/shared/product.ts
+++ b/shared/product.ts
@@ -8,6 +8,8 @@ export type Product = {
   stock: number;
   created_at: string;
   updated_at: string;
+  category1: string;
+  category2: string;
   category1_id: number;
   category2_id: number;
 };


### PR DESCRIPTION
## product detail page
다이나믹 라우팅을 이용해서, 싱글 프로덕트에 대한 라우팅 지원(디자인은 하지 않음)

## 아이콘 및 기타 버튼 들에 대한 인터렉션 추가
커지거나, 배경색이 바뀌거나
![image](https://user-images.githubusercontent.com/30615804/91281504-21cddd00-e7c3-11ea-867d-a8438099acad.png)

## stopPropagation
기타 아이콘을 눌렀을때, 이벤트 버블링이 일어나서 라우팅이 되버림, 이것을 해결하기 위해 해당 이벤트만 딱 작동하고, 버블링을 막는 event의 stopPropagation 메소드를 이용함

## header
- 좌측엔 뒤로가기, 우측엔 햄버거 버튼을 통한 사이드메뉴
- `title`이 props로 들어가면 비마트 로고 대신에 중앙에 타이틀로 들어감 